### PR TITLE
Add .xlsx (Excel) support to bulk role assignment

### DIFF
--- a/app/csv_utils.py
+++ b/app/csv_utils.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import csv
 import io
 
+from openpyxl import load_workbook
+
 _DANGEROUS_SPREADSHEET_PREFIXES = ("=", "+", "-", "@")
 
 
@@ -28,6 +30,33 @@ def parse_csv_cells(data: bytes) -> list[str]:
             if candidate:
                 values.append(candidate)
     return values
+
+
+def parse_xlsx_cells(data: bytes) -> list[str]:
+    """Extract all non-empty cell values from an xlsx file."""
+    try:
+        workbook = load_workbook(io.BytesIO(data), data_only=True, read_only=True)
+        values: list[str] = []
+        for sheet in workbook.sheetnames:
+            worksheet = workbook[sheet]
+            for row in worksheet.iter_rows(values_only=True):
+                for cell in row:
+                    if cell is not None:
+                        candidate = str(cell).strip()
+                        if candidate:
+                            values.append(candidate)
+        workbook.close()
+        return values
+    except Exception:
+        return []
+
+
+def parse_spreadsheet_cells(data: bytes, filename: str) -> list[str]:
+    """Parse cells from either CSV or XLSX file based on filename."""
+    if filename.lower().endswith(".xlsx"):
+        return parse_xlsx_cells(data)
+    else:
+        return parse_csv_cells(data)
 
 
 def sanitize_csv_cell(value: object) -> str:

--- a/bot.py
+++ b/bot.py
@@ -5338,8 +5338,9 @@ def normalize_member_lookup_name(value: str):
     return normalized or None
 
 
-def parse_member_names_from_csv_bytes(data: bytes):
-    return parse_csv_cells(data)
+def parse_member_names_from_csv_bytes(data: bytes, filename: str = ""):
+    from app.csv_utils import parse_spreadsheet_cells
+    return parse_spreadsheet_cells(data, filename)
 
 
 def build_member_name_lookup(guild: discord.Guild):
@@ -5460,8 +5461,9 @@ async def process_bulk_role_assignment_payload(
     payload: bytes,
     requested_by: str,
     reason_actor: str,
+    filename: str = "",
 ):
-    raw_names = parse_member_names_from_csv_bytes(payload)
+    raw_names = parse_member_names_from_csv_bytes(payload, filename)
     unique_names = unique_member_names(raw_names)
     if not unique_names:
         return None, "❌ The uploaded file did not contain any names."
@@ -11071,11 +11073,11 @@ async def restore_code(interaction: discord.Interaction, role: discord.Role, cod
 
 @tree.command(
     name="bulk_assign_role_csv",
-    description="Assign a role to members listed in an uploaded CSV file",
+    description="Assign a role to members listed in an uploaded CSV or XLSX file",
 )
 @app_commands.describe(
     role="Role to assign",
-    csv_file="Upload a .csv containing Discord names (comma-separated or one-per-line)",
+    csv_file="Upload a .csv or .xlsx containing Discord names (comma-separated or one-per-line)",
 )
 async def bulk_assign_role_csv(interaction: discord.Interaction, role: discord.Role, csv_file: discord.Attachment):
     logger.info("/bulk_assign_role_csv invoked by %s", interaction.user)
@@ -11114,9 +11116,9 @@ async def bulk_assign_role_csv(interaction: discord.Interaction, role: discord.R
         )
         return
 
-    if not csv_file.filename.lower().endswith(".csv"):
+    if not (csv_file.filename.lower().endswith(".csv") or csv_file.filename.lower().endswith(".xlsx")):
         await interaction.response.send_message(
-            "❌ The uploaded file must be a `.csv` file.",
+            "❌ The uploaded file must be a `.csv` or `.xlsx` file.",
             ephemeral=True,
         )
         return
@@ -11136,6 +11138,7 @@ async def bulk_assign_role_csv(interaction: discord.Interaction, role: discord.R
         payload=payload,
         requested_by=str(interaction.user),
         reason_actor=f"Bulk CSV role assignment by {interaction.user} ({interaction.user.id})",
+        filename=csv_file.filename,
     )
     if error:
         await interaction.followup.send(error, ephemeral=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ cryptography==46.0.7
 defusedxml==0.7.1
 wheel==0.46.2
 jaraco.context==6.1.0
+openpyxl==3.1.5

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -1,7 +1,8 @@
 import csv
 import io
 
-from app.csv_utils import build_csv_bytes, parse_csv_cells
+from app.csv_utils import build_csv_bytes, parse_csv_cells, parse_xlsx_cells, parse_spreadsheet_cells
+from openpyxl import Workbook
 
 
 def test_parse_csv_cells_supports_utf8_bom_and_multiple_cells():
@@ -24,3 +25,39 @@ def test_build_csv_bytes_escapes_formula_like_cells():
         ["'=cmd", "'+sum"],
         ["'-value", "'@mention"],
     ]
+
+
+def test_parse_xlsx_cells_extracts_all_values():
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet["A1"] = "Alice"
+    sheet["B1"] = "Bob"
+    sheet["A2"] = "Charlie"
+    sheet["B2"] = "Diana"
+    
+    excel_bytes = io.BytesIO()
+    workbook.save(excel_bytes)
+    excel_bytes.seek(0)
+    
+    result = parse_xlsx_cells(excel_bytes.getvalue())
+    assert set(result) == {"Alice", "Bob", "Charlie", "Diana"}
+
+
+def test_parse_spreadsheet_cells_handles_csv():
+    payload = "Alpha, Beta\nGamma\n".encode()
+    result = parse_spreadsheet_cells(payload, "names.csv")
+    assert result == ["Alpha", "Beta", "Gamma"]
+
+
+def test_parse_spreadsheet_cells_handles_xlsx():
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet["A1"] = "Alice"
+    sheet["B1"] = "Bob"
+    
+    excel_bytes = io.BytesIO()
+    workbook.save(excel_bytes)
+    excel_bytes.seek(0)
+    
+    result = parse_spreadsheet_cells(excel_bytes.getvalue(), "names.xlsx")
+    assert set(result) == {"Alice", "Bob"}

--- a/web_admin.py
+++ b/web_admin.py
@@ -8431,18 +8431,18 @@ def create_web_app(
             if not role_input:
                 flash("Role selection is required.", "error")
             elif uploaded_file is None or not uploaded_file.filename:
-                flash("CSV file is required.", "error")
-            elif not uploaded_file.filename.lower().endswith(".csv"):
-                flash("Uploaded file must be a .csv file.", "error")
+                flash("Spreadsheet file is required.", "error")
+            elif not (uploaded_file.filename.lower().endswith(".csv") or uploaded_file.filename.lower().endswith(".xlsx")):
+                flash("Uploaded file must be a .csv or .xlsx file.", "error")
             elif not callable(on_bulk_assign_role_csv):
-                flash("Bulk CSV assignment is not configured in this runtime.", "error")
+                flash("Bulk spreadsheet assignment is not configured in this runtime.", "error")
             else:
                 payload = uploaded_file.read()
                 if not payload:
-                    flash("Uploaded CSV is empty.", "error")
+                    flash("Uploaded file is empty.", "error")
                 elif len(payload) > max_upload_bytes:
                     flash(
-                        f"CSV file is too large ({len(payload)} bytes). Max allowed is {max_upload_bytes} bytes.",
+                        f"File is too large ({len(payload)} bytes). Max allowed is {max_upload_bytes} bytes.",
                         "error",
                     )
                 else:
@@ -8515,15 +8515,15 @@ def create_web_app(
 
         body = f"""
         <div class="card">
-          <h2>Bulk Assign Role from CSV</h2>
+          <h2>Bulk Assign Role from Spreadsheet</h2>
           <p class="muted">Selected server: <strong>{escape(str(selected_guild.get("name") or "Unknown"))}</strong></p>
-          <p class="muted">Upload a CSV of Discord names (comma-separated or one-per-line), and assign all matched members to the specified role.</p>
+          <p class="muted">Upload a CSV or Excel file with Discord names (comma-separated or one-per-line), and assign all matched members to the specified role.</p>
           <p class="muted">Current upload limit: {max_upload_bytes} bytes. Current per-section display limit: {report_list_limit} entries.</p>
           <form method="post" enctype="multipart/form-data">
             {role_picker_html}
             {"<label>Role ID (or role mention like &lt;@&amp;123&gt;)</label><input type='text' name='role_id' placeholder='123456789012345678' />" if not role_options else ""}
-            <label style="margin-top:10px;display:block;">CSV file</label>
-            <input type="file" name="csv_file" accept=".csv,text/csv" required />
+            <label style="margin-top:10px;display:block;">Spreadsheet file (.csv or .xlsx)</label>
+            <input type="file" name="csv_file" accept=".csv,text/csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" required />
             <div style="margin-top:14px;">
               <button class="btn" type="submit">Run Bulk Assignment</button>
             </div>

--- a/wiki/Bulk-CSV-Role-Assignment.md
+++ b/wiki/Bulk-CSV-Role-Assignment.md
@@ -1,6 +1,6 @@
-# Bulk CSV Role Assignment
+# Bulk CSV/XLSX Role Assignment
 
-Bulk-assign an existing role to many members from uploaded CSV input.
+Bulk-assign an existing role to many members from uploaded spreadsheet input (CSV or Excel files).
 
 ## Command and Web Path
 
@@ -11,12 +11,24 @@ Bulk-assign an existing role to many members from uploaded CSV input.
 
 ## Input Formats
 
-Accepted input variations:
+Accepted file formats:
+
+- **CSV (.csv)**: Comma-separated values or one name per line
+- **Excel (.xlsx)**: Excel workbooks with names in cells
+
+Supported CSV input variations:
 
 - Comma-separated names in one or more rows
 - One name per line
 - Mixed whitespace and separators
 - UTF-8, UTF-8 with BOM, and Latin-1 uploads are accepted
+
+Excel (.xlsx) files:
+
+- All non-empty cell values from all sheets are extracted
+- Cells are read in order (top-to-bottom, left-to-right, sheet-by-sheet)
+- Values are normalized to text strings
+- Excel formulas are evaluated if cached in the file
 
 Normalized matching attempts:
 


### PR DESCRIPTION
## Summary

Enables bulk role assignment to accept both CSV and Excel (.xlsx) files in addition to CSV. Users can now upload spreadsheets in either format when performing bulk role assignments.

## Changes

- **app/csv_utils.py**: Added `parse_xlsx_cells()` to extract data from Excel files and `parse_spreadsheet_cells()` for automatic file type detection
- **bot.py**: Updated `/bulk_assign_role_csv` command to accept .csv and .xlsx files with updated descriptions
- **web_admin.py**: Updated web interface to support Excel uploads with file input accepting both formats
- **requirements.txt**: Added `openpyxl==3.1.5` dependency for Excel file handling
- **tests/test_csv_utils.py**: Added comprehensive tests for XLSX parsing functionality
- **wiki/Bulk-CSV-Role-Assignment.md**: Updated documentation to reflect Excel support

## Implementation Details

- Excel files are parsed sheet-by-sheet, extracting all non-empty cell values
- File type is automatically detected based on filename extension
- All existing CSV functionality is preserved with backward compatibility
- Formula values are evaluated if cached in the Excel file

## Testing

All 5 tests pass:
- ✅ CSV parsing with UTF-8 BOM support
- ✅ CSV formula escaping
- ✅ XLSX cell extraction
- ✅ Automatic CSV format detection
- ✅ Automatic XLSX format detection

Ready for review.