### PR TITLE
docs: remove full logo image from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # GL.iNet UnOfficial Discord Bot
 
 <p align="center">
-  <img src="./assets/images/glinet-bot-round.png" alt="GL.iNet Bot Logo (Round)" width="170" />
-  <img src="./assets/images/glinet-bot-full.png" alt="GL.iNet Bot Logo (Full)" width="240" />
+  <img src="./assets/images/glinet-bot-round.png" alt="GL.iNet Bot Logo (Round)" width="250" />
 </p>
 
 Discord bot for GL.iNet community operations under the public `GL.iNet UnOfficial Discord Bot` name, with invite/code role access, moderation tools, search helpers, firmware/YouTube/LinkedIn/beta-program monitoring, member-activity analytics, utility commands, and a secured multi-guild web admin GUI.


### PR DESCRIPTION
Remove the glinet-bot-full.png image from the README center image block and keep the round logo centered.