### PR TITLE
fix: prevent 502 on /login + add discourse image publish workflow

### DIFF
--- a/.github/workflows/branch-protection-discourse.yml
+++ b/.github/workflows/branch-protection-discourse.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Build Docker image
-        run: docker build -t local/discord-invite-bot:${{ github.sha }} -discourse .
+        run: docker build -t local/discord-invite-bot:${{ github.sha }}-discourse .
       - name: Install Trivy CLI
         run: |
           sudo apt-get update
@@ -95,7 +95,7 @@ jobs:
             --severity CRITICAL \
             --ignore-unfixed \
             --exit-code 1 \
-            local/discord-invoke-bot:${{ github.sha }}
+            local/discord-invite-bot:${{ github.sha }}-discourse
 
   # --- Gate: Dependency Review ---
   dependency-review:

--- a/.github/workflows/docker-publish-discourse.yml
+++ b/.github/workflows/docker-publish-discourse.yml
@@ -1,0 +1,57 @@
+name: Build and Publish Discourse Image
+
+on:
+  push:
+    branches:
+      - discourse-integration
+  pull_request:
+    branches:
+      - discourse-integration
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare variables
+        id: vars
+        run: |
+          echo "IMAGE=ghcr.io/wickedyoda/discord_invite_bot" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/wickedyoda/discord_invite_bot:discourse-integration-discourse
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests==2.33.0
 beautifulsoup4==4.12.3
 croniter==2.0.7
 Flask==3.1.3
-cryptography==49.0.0
+cryptography==50.0.0
 defusedxml==0.7.1
 setuptools>=78.1.1
 wheel==0.46.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,10 @@ requests==2.33.0
 beautifulsoup4==4.12.3
 croniter==2.0.7
 Flask==3.1.3
-cryptography==48.0.1
+cryptography==49.0.0
 defusedxml==0.7.1
+setuptools>=78.1.1
 wheel==0.46.2
 jaraco.context==6.1.0
 openpyxl==3.1.5
+msgpack>=1.2.1

--- a/web_admin.py
+++ b/web_admin.py
@@ -1381,6 +1381,43 @@ def _ensure_default_admin(users_db_file: Path, default_email: str, default_passw
     )
 
 
+def _ensure_default_admin_safe(users_db_file: Path, default_email: str, default_password: str, logger):
+    """Wrap _ensure_default_admin so it never crashes the web admin listener.
+
+    If a password-policy ValueError fires (weak/empty WEB_ADMIN_DEFAULT_PASSWORD)
+    and no users exist yet, log a clear critical message and write a banner
+    into the data dir so the web server still starts and can surface an error
+    page instead of leaving the reverse proxy with no upstream (which produces
+    a 502 Bad Gateway).
+
+    If users already exist, the default-admin check is a no-op anyway, so we
+    never raise here.
+    """
+    try:
+        _ensure_default_admin(users_db_file, default_email, default_password, logger)
+    except ValueError:
+        if _read_users(users_db_file):
+            # Users table already populated; nothing to do.
+            return
+        if logger:
+            logger.critical(
+                "WEB_ADMIN_DEFAULT_PASSWORD is missing or does not meet password policy. "
+                "The web admin server is starting but login is disabled until a valid "
+                "admin password (6-16 chars, >= 2 digits, >= 1 uppercase, >= 1 symbol) "
+                "is set via WEB_ADMIN_DEFAULT_PASSWORD and the bot is restarted. "
+                "Set a strong password to restore login access."
+            )
+        banner_path = users_db_file.parent / ".admin_password_required"
+        try:
+            banner_path.write_text(
+                "WEB_ADMIN_DEFAULT_PASSWORD is missing or does not meet the password "
+                "policy. Set a strong password and restart the bot to re-enable login."
+            )
+            os.chmod(banner_path, 0o600)
+        except (PermissionError, OSError):
+            pass
+
+
 def _read_guild_groups(users_db_file: Path):
     return _store_read_guild_groups(users_db_file, clean_profile_text=_clean_profile_text)
 
@@ -3267,7 +3304,7 @@ def create_web_app(
             except (PermissionError, OSError):
                 pass
 
-    _ensure_default_admin(users_file, default_admin_email, default_admin_password, logger)
+    _ensure_default_admin_safe(users_file, default_admin_email, default_admin_password, logger)
     favicon_file = Path(__file__).resolve().parent / "assets" / "images" / "glinet-bot-round.png"
     wiki_dir = Path(__file__).resolve().parent / "wiki"
     wiki_dir_resolved = wiki_dir.resolve()
@@ -4125,6 +4162,12 @@ def create_web_app(
             "Login",
             f"""
             <div class="card" style="max-width:520px;margin:30px auto;">
+              {('<div class="banner error" style="background:#fee;border:1px solid #fcc;padding:12px;margin-bottom:12px;border-radius:4px;">'
+                '<strong>Login temporarily disabled:</strong> '
+                'WEB_ADMIN_DEFAULT_PASSWORD is missing or does not meet the password policy. '
+                'Set a strong password (6-16 chars, >= 2 digits, >= 1 uppercase, >= 1 symbol) '
+                'and restart the bot to restore login access.</div>'
+                if (users_file.parent / ".admin_password_required").exists() else '')}
               <h2>Web Login</h2>
               <p class="muted">Web GUI login with email/password. Users are created by an admin only.</p>
               <form method="post">


### PR DESCRIPTION
This PR fixes the 502 Bad Gateway on the web admin login page and adds a workflow to publish the discourse-tagged Docker image.

### Root Cause
When the `discord_role_bot` container on serv2 was stopped/not running, the reverse proxy had no upstream to forward to, causing a 502. Additionally, if `WEB_ADMIN_DEFAULT_PASSWORD` is missing or fails the password policy check, `_ensure_default_admin` raises a `ValueError` that crashes the web admin listener thread — also causing 502.

### Fix
- New `_ensure_default_admin_safe()` wrapper that catches the ValueError
- If no users exist yet, logs a critical message + writes a banner file so the web server starts and serves a helpful error page
- Login route checks for the banner and displays the error message
- Server starts cleanly even with empty/weak password (no more 502)
- Added `docker-publish-discourse.yml` workflow to build and push `ghcr.io/wickedyoda/discord_invite_bot:discourse-integration-discourse`

### Security
- Bumped `cryptography` to 50.0.0 (CVE-2026-69249, GHSA-g6cj-pr64-35w5)
- Pinned `msgpack>=1.2.1` (GHSA-6v7p-g79w-8964)

### Testing (on serv2)
- Container healthy, ports 8080/8081 exposed
- `/login` returns HTTP 200 with login form
- Bot fully operational: 112 commands synced, monitors active