### PR TITLE
feat: add read-only Freshdesk ticket viewer integration

### DIFF
--- a/app/freshdesk_api.py
+++ b/app/freshdesk_api.py
@@ -1,0 +1,321 @@
+"""Freshdesk API client — read-only.
+
+Provides read-only helpers for searching tickets, viewing ticket details,
+and listing categories/solutions on GL.iNet's Freshdesk instance.
+
+All write endpoints are intentionally **not** implemented here.
+
+Authentication uses API-key basic auth (`api_key:X`), per the Freshdesk docs.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from html import unescape
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- #
+#  Errors
+# --------------------------------------------------------------------------- #
+class FreshdeskApiError(RuntimeError):
+    """Base error for Freshdesk API failures."""
+
+
+class FreshdeskRateLimitError(FreshdeskApiError):
+    """Raised when Freshdesk returns HTTP 429 (rate limited)."""
+
+
+# --------------------------------------------------------------------------- #
+#  Text helpers
+# --------------------------------------------------------------------------- #
+def clean_freshdesk_text(value: Any) -> str:
+    """Strip HTML tags and decode entities from Freshdesk text fields."""
+    text = str(value or "")
+    cleaned: list[str] = []
+    in_tag = False
+    for char in text:
+        if char == "<":
+            in_tag = True
+            continue
+        if char == ">":
+            in_tag = False
+            cleaned.append(" ")
+            continue
+        if not in_tag:
+            cleaned.append(char)
+    # Collapse whitespace
+    return " ".join(unescape("".join(cleaned)).split())
+
+
+# --------------------------------------------------------------------------- #
+#  Headers / auth
+# --------------------------------------------------------------------------- #
+FRESHDESK_USER_AGENT = "GLiNetDiscordBot/1.0 (+https://github.com/wickedyoda/Glinet_discord_bot)"
+
+
+def _build_headers(api_key: str) -> dict[str, str]:
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": FRESHDESK_USER_AGENT,
+    }
+    if str(api_key or "").strip():
+        # Freshdesk uses API-key basic auth: api_key:X
+        import base64
+        token = base64.b64encode(f"{api_key}:X".encode()).decode()
+        headers["Authorization"] = f"Basic {token}"
+    return headers
+
+
+def _check_rate_limit(response: requests.Response, source_name: str):
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    if status_code == 429:
+        retry_after = response.headers.get("Retry-After", "60")
+        raise FreshdeskRateLimitError(
+            f"{source_name} is rate-limited. Retry after {retry_after}s."
+        )
+    if status_code in (401, 403):
+        raise FreshdeskApiError(f"{source_name} authentication failed (HTTP {status_code}).")
+    if status_code >= 400:
+        raise FreshdeskApiError(f"{source_name} request failed with HTTP {status_code}.")
+
+
+# --------------------------------------------------------------------------- #
+#  Search tickets
+# --------------------------------------------------------------------------- #
+def search_freshdesk_tickets(
+    *,
+    base_url: str,
+    query: str,
+    max_results: int = 10,
+    timeout_seconds: int = 15,
+    api_key: str = "",
+) -> list[dict[str, Any]]:
+    """Search Freshdesk tickets using the Filter Tickets API.
+
+    Query syntax: ``"status:2"``, ``"priority:4 OR priority:3"``, etc.
+    See https://developer.freshdesk.com/api/#filter_tickets
+    """
+    endpoint = f"{base_url.rstrip('/')}/api/v2/search/tickets"
+    params: dict[str, Any] = {}
+    if query.strip():
+        params["query"] = query.strip()
+
+    tickets: list[dict[str, Any]] = []
+    page = 1
+    while len(tickets) < max_results:
+        params["page"] = page
+        response = requests.get(
+            endpoint, params=params, timeout=timeout_seconds,
+            headers=_build_headers(api_key),
+        )
+        _check_rate_limit(response, "Freshdesk ticket search")
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise FreshdeskApiError("Freshdesk returned invalid JSON for ticket search.") from exc
+
+        results = data.get("results", []) if isinstance(data, dict) else []
+        if not isinstance(results, list) or not results:
+            break
+        for item in results:
+            _append_ticket(tickets, item, base_url, max_results)
+        if len(results) < 30:  # last page
+            break
+        page += 1
+        if page > 10:  # safety limit
+            break
+    return tickets
+
+
+def _append_ticket(
+    tickets: list[dict[str, Any]],
+    item: dict[str, Any],
+    base_url: str,
+    max_results: int,
+) -> None:
+    if not isinstance(item, dict):
+        return
+    ticket_id = item.get("id") or item.get("subject_id")
+    if not ticket_id or len(tickets) >= max_results:
+        return
+    subject = clean_freshdesk_text(item.get("subject", ""))[:200]
+    ticket_url = f"{base_url.rstrip('/')}/helpdesk/tickets/{ticket_id}"
+    tickets.append({
+        "id": int(ticket_id),
+        "subject": subject,
+        "url": ticket_url,
+        "status": str(item.get("status", "")),
+        "priority": str(item.get("priority", "")),
+        "type": str(item.get("ticket_type", "")).strip() or "N/A",
+        "created_at": str(item.get("created_at", "")),
+        "updated_at": str(item.get("updated_at", "")),
+        "requester_name": str(item.get("requester", {}).get("name", "")) if isinstance(item.get("requester"), dict) else "",
+        "agent_id": item.get("responder_id") or item.get("agent_id"),
+    })
+
+
+# --------------------------------------------------------------------------- #
+#  View a single ticket
+# --------------------------------------------------------------------------- #
+def fetch_freshdesk_ticket(
+    *,
+    base_url: str,
+    ticket_id: int,
+    timeout_seconds: int = 15,
+    api_key: str = "",
+) -> dict[str, Any]:
+    """View a single Freshdesk ticket by ID.
+
+    Uses GET /api/v2/tickets/[id]
+    """
+    endpoint = f"{base_url.rstrip('/')}/api/v2/tickets/{int(ticket_id)}"
+    response = requests.get(endpoint, timeout=timeout_seconds, headers=_build_headers(api_key))
+    _check_rate_limit(response, "Freshdesk ticket view")
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise FreshdeskApiError("Freshdesk returned invalid JSON for ticket view.") from exc
+    if not isinstance(data, dict):
+        return {}
+    return _normalize_ticket_detail(data, base_url)
+
+
+def _normalize_ticket_detail(data: dict, base_url: str) -> dict[str, Any]:
+    ticket_id = data.get("id", 0)
+    descriptions = data.get("description_text") or data.get("description") or ""
+    return {
+        "id": int(ticket_id or 0),
+        "subject": clean_freshdesk_text(data.get("subject", ""))[:300],
+        "description": clean_freshdesk_text(descriptions)[:2000],
+        "status": _status_label(int(data.get("status", 2))),
+        "priority": _priority_label(int(data.get("priority", 1))),
+        "type": str(data.get("type", "")).strip() or "N/A",
+        "url": f"{base_url.rstrip('/')}/helpdesk/tickets/{ticket_id}" if ticket_id else "",
+        "created_at": str(data.get("created_at", "")),
+        "updated_at": str(data.get("updated_at", "")),
+        "due_at": str(data.get("due_by", "")),
+        "tags": [str(t) for t in (data.get("tags") or []) if str(t).strip()],
+        "requester": {
+            "name": str(data.get("requester", {}).get("name", "")) if isinstance(data.get("requester"), dict) else "",
+            "email": str(data.get("requester", {}).get("email", "")) if isinstance(data.get("requester"), dict) else "",
+        },
+        "responder_id": data.get("responder_id") or data.get("agent_id"),
+    }
+
+
+def _status_label(status_code: int) -> str:
+    labels = {
+        2: "Open", 3: "Pending", 4: "Resolved", 5: "Closed", 6: "Waiting on Customer",
+        7: "Waiting on External", 8: "Archived", 9: "Locked",
+    }
+    return labels.get(status_code, str(status_code))
+
+
+def _priority_label(priority_code: int) -> str:
+    labels = {1: "Low", 2: "Medium", 3: "High", 4: "Urgent"}
+    return labels.get(priority_code, str(priority_code))
+
+
+# --------------------------------------------------------------------------- #
+#  List ticket fields (categories, etc.)
+# --------------------------------------------------------------------------- #
+def list_freshdesk_ticket_fields(
+    *,
+    base_url: str,
+    timeout_seconds: int = 15,
+    api_key: str = "",
+) -> list[dict[str, Any]]:
+    """List available ticket fields (for understanding available filterable fields).
+
+    Uses GET /api/v2/ticket_fields
+    """
+    endpoint = f"{base_url.rstrip('/')}/api/v2/ticket_fields"
+    response = requests.get(endpoint, timeout=timeout_seconds, headers=_build_headers(api_key))
+    _check_rate_limit(response, "Freshdesk ticket fields")
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise FreshdeskApiError("Freshdesk returned invalid JSON for ticket fields.") from exc
+    if not isinstance(data, list):
+        return []
+    return [
+        {
+            "name": str(field.get("name", "")),
+            "label": str(field.get("label", "")),
+            "type": str(field.get("type", "")),
+        }
+        for field in data
+        if isinstance(field, dict)
+    ]
+
+
+# --------------------------------------------------------------------------- #
+#  List solution categories (knowledge base)
+# --------------------------------------------------------------------------- #
+def list_freshdesk_solution_categories(
+    *,
+    base_url: str,
+    timeout_seconds: int = 15,
+    api_key: str = "",
+) -> list[dict[str, Any]]:
+    """List Freshdesk solution (knowledge base) categories.
+
+    Uses GET /api/v2/solutions/categories
+    """
+    endpoint = f"{base_url.rstrip('/')}/api/v2/solutions/categories"
+    response = requests.get(endpoint, timeout=timeout_seconds, headers=_build_headers(api_key))
+    _check_rate_limit(response, "Freshdesk solution categories")
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise FreshdeskApiError("Freshdesk returned invalid JSON for solution categories.") from exc
+    if not isinstance(data, list):
+        return []
+    return [
+        {
+            "id": int(cat.get("id", 0) or 0),
+            "name": clean_freshdesk_text(cat.get("name", "")),
+            "description": clean_freshdesk_text(cat.get("description", "")),
+            "url": f"{base_url.rstrip('/')}/solutions/categories/{cat.get('id', 0)}" if cat.get("id") else "",
+        }
+        for cat in data
+        if isinstance(cat, dict)
+    ]
+
+
+# --------------------------------------------------------------------------- #
+#  Configuration helpers
+# --------------------------------------------------------------------------- #
+FRESHDESK_ENV_KEYS = {
+    "FRESHDESK_BASE_URL",
+    "FRESHDESK_API_KEY",
+    "FRESHDESK_REQUEST_TIMEOUT_SECONDS",
+}
+
+
+def build_freshdesk_config(env_values: dict[str, str]) -> dict[str, Any]:
+    """Build effective Freshdesk config from environment values."""
+    base_url = str(env_values.get("FRESHDESK_BASE_URL", "")).strip()
+    api_key = str(env_values.get("FRESHDESK_API_KEY", "")).strip()
+    timeout = 15
+    try:
+        timeout = int(env_values.get("FRESHDESK_REQUEST_TIMEOUT_SECONDS", "15") or "15")
+        if timeout < 3:
+            timeout = 15
+    except (ValueError, TypeError):
+        timeout = 15
+    return {
+        "base_url": base_url,
+        "api_key": api_key,
+        "timeout": timeout,
+    }
+
+
+def freshdesk_configured(config: dict[str, Any]) -> bool:
+    """Check if Freshdesk is properly configured (base URL + API key)."""
+    return bool(str(config.get("base_url", "")).strip()) and bool(str(config.get("api_key", "")).strip())

--- a/app/freshdesk_web_helpers.py
+++ b/app/freshdesk_web_helpers.py
@@ -1,0 +1,189 @@
+"""Web-side helpers for Freshdesk viewer rendering (read-only).
+
+Contains the HTML body builders and config normalizers used by
+``app/web_freshdesk_routes.py`` so that all Freshdesk web logic
+lives in one module — mirroring the ``app/web_discourse.py`` pattern.
+"""
+from __future__ import annotations
+
+from html import escape
+from typing import Any
+
+
+def build_freshdesk_config_from_env(env_values: dict[str, Any]) -> dict[str, Any]:
+    """Extract Freshdesk API config from environment values.
+
+    Re-exports ``freshdesk_api.build_freshdesk_config`` for use
+    by web-side helpers (mirrors the ``web_discourse`` pattern).
+    """
+    from app.freshdesk_api import build_freshdesk_config
+    return build_freshdesk_config(env_values)
+
+
+def freshdesk_configured(config: dict[str, Any]) -> bool:
+    """Check if Freshdesk is properly configured (base URL + API key)."""
+    return bool(str(config.get("base_url", "")).strip()) and bool(str(config.get("api_key", "")).strip())
+
+
+# --------------------------------------------------------------------------- #
+#  Status / priority labels
+# --------------------------------------------------------------------------- #
+FRESHDESK_STATUS_LABELS = {
+    2: "Open", 3: "Pending", 4: "Resolved", 5: "Closed",
+    6: "Waiting on Customer", 7: "Waiting on External",
+    8: "Archived", 9: "Locked",
+}
+
+FRESHDESK_PRIORITY_LABELS = {1: "Low", 2: "Medium", 3: "High", 4: "Urgent"}
+
+
+def format_freshdesk_status(status_code: Any) -> str:
+    try:
+        return FRESHDESK_STATUS_LABELS.get(int(status_code), str(status_code))
+    except (ValueError, TypeError):
+        return str(status_code)
+
+
+def format_freshdesk_priority(priority_code: Any) -> str:
+    try:
+        return FRESHDESK_PRIORITY_LABELS.get(int(priority_code), str(priority_code))
+    except (ValueError, TypeError):
+        return str(priority_code)
+
+
+# --------------------------------------------------------------------------- #
+#  Viewer page body
+# --------------------------------------------------------------------------- #
+def render_freshdesk_viewer_body(
+    *,
+    guild_name: str,
+    effective_settings: dict[str, Any],
+) -> str:
+    """Render the read-only Freshdesk viewer page showing integration settings and live ticket data.
+
+    Parameters
+    ----------
+    guild_name
+        Name of the currently selected guild (for display).
+    effective_settings
+        Dict with keys: ``freshdesk_base_url``, ``freshdesk_api_key``,
+        ``freshdesk_request_timeout_seconds``.
+    """
+    config = build_freshdesk_config_from_env(effective_settings)
+    base_url = config["base_url"]
+    api_key_configured = bool(config["api_key"])
+    timeout = config["timeout"]
+
+    integration_rows = [
+        ("Helpdesk URL", base_url or "Not configured"),
+        ("API Key", "Configured" if api_key_configured else "Not configured"),
+        ("Request Timeout", f"{timeout} second(s)"),
+        ("Scope", "Read-only (search, view, browse)"),
+    ]
+
+    integration_items = "".join(
+        f"""
+        <tr>
+          <td><strong>{escape(label)}</strong></td>
+          <td class='muted mono'>{escape(value)}</td>
+        </tr>
+        """
+        for label, value in integration_rows
+    )
+
+    search_form = f"""
+    <div class='card'>
+      <h3 style='margin-top:0;'>Search Tickets</h3>
+      <p class='muted'>Search GL.iNet Freshdesk tickets by query (e.g. <code>status:2</code>).</p>
+      <form method='get' action='/admin/freshdesk/viewer/search' style='margin-bottom:8px;'>
+        <input type='text' name='q' placeholder='Search query...' style='width:400px;' />
+        <button class='btn' type='submit'>Search</button>
+      </form>
+    </div>
+    """
+
+    categories_card = f"""
+    <div class='card'>
+      <h3 style='margin-top:0;'>Solution Categories</h3>
+      <p class='muted'>Solution/knowledge-base categories from {escape(base_url or 'Freshdesk')}</p>
+      <div id='freshdesk-categories' class='muted'>Loading categories...</div>
+    </div>
+    """
+
+    available_options = """
+    <div class='card'>
+      <h3 style='margin-top:0;'>Available Actions</h3>
+      <ul>
+        <li><strong>/freshdesk search &lt;query&gt;</strong> — Discord command to search Freshdesk tickets</li>
+        <li><strong>/freshdesk ticket &lt;id&gt;</strong> — Discord command to view ticket details</li>
+        <li><strong>/freshdesk categories</strong> — Discord command to list solution categories</li>
+      </ul>
+    </div>
+    """
+
+    forum_html = "".join([search_form, categories_card, available_options])
+
+    return f"""
+    <div class='card'>
+      <h2>Freshdesk Ticket Viewer</h2>
+      <p class='muted'>Read-only view of GL.iNet support tickets via Freshdesk for <strong>{escape(guild_name)}</strong>.
+         This page allows searching and viewing Freshdesk tickets without modifying any data.
+         {'' if api_key_configured else ' <span class="warning">API key is not configured — live data may be unavailable.</span>'}
+      </p>
+
+      <div class='card' style='margin:16px 0 0 0;'>
+        <h3 style='margin-top:0;'>Integration Settings</h3>
+        <table>
+          <thead><tr><th>Setting</th><th>Value</th></tr></thead>
+          <tbody>
+            {integration_items}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    {forum_html}
+
+    <script>
+    (function() {{
+      var baseUrl = {repr(base_url or '')};
+      if (!baseUrl) return;
+      fetch('/admin/freshdesk/viewer/api/categories')
+        .then(function(r) {{ return r.json(); }})
+        .then(function(data) {{
+          var el = document.getElementById('freshdesk-categories');
+          if (data && data.categories && data.categories.length > 0) {{
+            el.innerHTML = data.categories.map(function(c) {{
+              return '<a href="' + escape(c.url) + '" target="_blank">' + escape(c.name) + '</a>';
+            }}).join('<br>');
+          }} else {{
+            el.textContent = 'No categories found or unable to fetch.';
+          }}
+        }})
+        .catch(function(e) {{
+          var el = document.getElementById('freshdesk-categories');
+          el.textContent = 'Error fetching categories: ' + e.message;
+        }});
+    }})();
+    </script>
+    """
+
+
+def render_freshdesk_search_results(
+    *,
+    search_query: str,
+    tickets: list[dict[str, Any]],
+    base_url: str,
+) -> str:
+    """Render search results as HTML links."""
+    if not tickets:
+        return "<p class='muted'>No tickets found for your search.</p>"
+
+    items = "".join(
+        f'<li><a href="{escape(str(t.get("url", "")))}" target="_blank">'
+        f"#{t.get('id', '?')} — {escape(str(t.get('subject', 'No subject'))[:200])}</a>"
+        f'<div class="muted">{escape(str(t.get("status", "")))} · '
+        f"{escape(str(t.get('type', '')))}</div></li>"
+        for t in tickets
+    )
+    return f"<ul>{items}</ul>"

--- a/app/web_freshdesk_routes.py
+++ b/app/web_freshdesk_routes.py
@@ -1,0 +1,255 @@
+"""Freshdesk viewer routes — read-only Flask Blueprint.
+
+Extracted from ``web_admin.py``'s ``create_web_app`` to keep the
+monolith manageable and Freshdesk viewer logic self-contained,
+following the same pattern as the Discourse viewer blueprint.
+
+The blueprint is registered from ``create_web_app`` via
+``register_freshdesk_viewer_blueprint(app, **helpers)`` where each
+keyword argument is a closure defined inside ``create_web_app``
+(e.g. ``_current_user``, ``_selected_guild``, ``_render_page`` …).
+"""
+from __future__ import annotations
+
+from html import escape
+from typing import Any
+
+from flask import Blueprint, jsonify, request
+
+from app.freshdesk_api import (
+    FreshdeskApiError,
+    FreshdeskRateLimitError,
+    fetch_freshdesk_ticket,
+    list_freshdesk_solution_categories,
+    search_freshdesk_tickets,
+)
+from app.freshdesk_web_helpers import render_freshdesk_viewer_body
+
+bp = Blueprint("freshdesk_viewer", __name__, url_prefix="/admin/freshdesk/viewer")
+
+# These are injected by ``register_freshdesk_viewer_blueprint``.
+_h = {}  # type: dict[str, object]
+
+
+# --------------------------------------------------------------------------- #
+#  Helpers
+# --------------------------------------------------------------------------- #
+def _current_user():
+    return _h["current_user"]()  # type: ignore[operator]
+
+
+def _selected_guild():
+    return _h["selected_guild"]() or {}  # type: ignore[operator]
+
+
+def _require_selected_guild_redirect():
+    return _h["require_selected_guild_redirect"]()  # type: ignore[operator]
+
+
+def _render_page(title: str, body: str, email: str, is_admin: bool):
+    return _h["render_page"](title, body, email, is_admin)  # type: ignore[operator]
+
+
+# --------------------------------------------------------------------------- #
+#  Page routes
+# --------------------------------------------------------------------------- #
+@bp.route("/", methods=["GET"], endpoint="freshdesk_viewer_page")
+def viewer_page():
+    user = _current_user()
+    selection_redirect = _require_selected_guild_redirect()
+    if selection_redirect is not None:
+        return selection_redirect
+    selected_guild = _selected_guild()
+    guild_name = str(selected_guild.get("name") or "Unknown")
+    selected_guild_id = str(selected_guild.get("id") or "")
+
+    env_values = _resolve_env_values()
+
+    body = render_freshdesk_viewer_body(
+        guild_name=guild_name,
+        effective_settings=env_values,
+    )
+    return _render_page("Freshdesk Viewer", body, user["email"], bool(user.get("is_admin")))
+
+
+@bp.route("/search", methods=["GET"], endpoint="freshdesk_viewer_search")
+def search():
+    user = _current_user()
+    selection_redirect = _require_selected_guild_redirect()
+    if selection_redirect is not None:
+        return selection_redirect
+
+    search_query = str(request.args.get("q", "")).strip()
+    env_values = _resolve_env_values()
+
+    base_url = str(env_values.get("freshdesk_base_url", "")).rstrip("/")
+    api_key = str(env_values.get("freshdesk_api_key", "")).strip()
+    timeout = int(env_values.get("freshdesk_request_timeout_seconds", 15))
+
+    search_results_html = ""
+    if search_query and base_url and api_key:
+        try:
+            tickets = search_freshdesk_tickets(
+                base_url=base_url,
+                query=search_query,
+                max_results=20,
+                timeout_seconds=timeout,
+                api_key=api_key,
+            )
+            if tickets:
+                result_items = "".join(
+                    f'<li><a href="{escape(str(t["url"]))}" target="_blank">'
+                    f"#{t['id']} — {escape(t['subject'])}</a>"
+                    f'<div class="muted">{escape(t.get("status", ""))} · {escape(t.get("type", ""))}</div></li>'
+                    for t in tickets
+                )
+                search_results_html = f"<ul>{result_items}</ul>"
+            else:
+                search_results_html = "<p class='muted'>No tickets found for your search.</p>"
+        except (FreshdeskApiError, FreshdeskRateLimitError) as exc:
+            search_results_html = f'<p class="warning">Search error: {escape(str(exc))}</p>'
+        except Exception as exc:  # noqa: BLE001
+            search_results_html = f'<p class="warning">Search error: {escape(str(exc))}</p>'
+    elif not search_query:
+        search_results_html = "<p class='muted'>Enter a search query above to search Freshdesk.</p>"
+    elif not api_key:
+        search_results_html = (
+            "<p class='warning'>Freshdesk API key is not configured. "
+            "Contact an administrator.</p>"
+        )
+
+    body = f"""
+    <div class='card'>
+      <h2>Freshdesk Ticket Search</h2>
+      <p class='muted'>Searching <strong>{escape(base_url or 'not configured')}</strong> for <strong>{escape(search_query)}</strong></p>
+      <form method='get' action='/admin/freshdesk/viewer/search' style='margin-bottom:12px;'>
+        <input type='text' name='q' value='{escape(search_query, quote=True)}' placeholder='Search query...' style='width:400px;' />
+        <button class='btn' type='submit'>Search</button>
+      </form>
+      {search_results_html}
+    </div>
+    """
+    return _render_page("Freshdesk Search", body, user["email"], bool(user.get("is_admin")))
+
+
+@bp.route("/ticket/<int:ticket_id>", methods=["GET"], endpoint="freshdesk_viewer_ticket")
+def view_ticket(ticket_id: int):
+    user = _current_user()
+    selection_redirect = _require_selected_guild_redirect()
+    if selection_redirect is not None:
+        return selection_redirect
+
+    env_values = _resolve_env_values()
+    base_url = str(env_values.get("freshdesk_base_url", "")).rstrip("/")
+    api_key = str(env_values.get("freshdesk_api_key", "")).strip()
+    timeout = int(env_values.get("freshdesk_request_timeout_seconds", 15))
+
+    ticket_html = "<p class='muted'>No ticket ID provided.</p>"
+    if base_url and api_key:
+        try:
+            ticket = fetch_freshdesk_ticket(
+                base_url=base_url,
+                ticket_id=ticket_id,
+                timeout_seconds=timeout,
+                api_key=api_key,
+            )
+            if ticket:
+                ticket_html = (
+                    f"<h3>#{ticket['id']} — {escape(ticket['subject'])}</h3>"
+                    f"<p class='muted'>{escape(ticket.get('status', ''))} · "
+                    f"{escape(ticket.get('priority', ''))} · "
+                    f"{escape(ticket.get('type', ''))}</p>"
+                    f"<div class='muted'>{escape(ticket.get('description', ''))}</div>"
+                    f"<p class='muted'>Created: {escape(ticket.get('created_at', ''))} | "
+                    f"Updated: {escape(ticket.get('updated_at', ''))}</p>"
+                    f'<p><a href="{escape(ticket.get("url", ""))}" target="_blank">View in Freshdesk</a></p>'
+                )
+            else:
+                ticket_html = "<p class='muted'>Ticket not found.</p>"
+        except (FreshdeskApiError, FreshdeskRateLimitError) as exc:
+            ticket_html = f'<p class="warning">Error loading ticket: {escape(str(exc))}</p>'
+        except Exception as exc:  # noqa: BLE001
+            ticket_html = f'<p class="warning">Error loading ticket: {escape(str(exc))}</p>'
+
+    body = f"""
+    <div class='card'>
+      <h2>Freshdesk Ticket</h2>
+      {ticket_html}
+    </div>
+    <div class='card'>
+      <a class='btn secondary' href='/admin/freshdesk/viewer'>Back to Viewer</a>
+    </div>
+    """
+    return _render_page("Freshdesk Ticket", body, user["email"], bool(user.get("is_admin")))
+
+
+# --------------------------------------------------------------------------- #
+#  API routes
+# --------------------------------------------------------------------------- #
+@bp.route("/api/categories", endpoint="freshdesk_viewer_api_categories")
+def api_categories():
+    user = _current_user()
+    if not str(user["email"]):
+        return jsonify({"ok": False, "error": "Not authenticated"}), 401
+
+    env_values = _resolve_env_values()
+    base_url = str(env_values.get("freshdesk_base_url", "")).rstrip("/")
+    api_key = str(env_values.get("freshdesk_api_key", "")).strip()
+    timeout = int(env_values.get("freshdesk_request_timeout_seconds", 15))
+
+    if not base_url or not api_key:
+        return jsonify({"ok": False, "error": "Freshdesk not configured"}), 400
+
+    try:
+        categories = list_freshdesk_solution_categories(
+            base_url=base_url,
+            timeout_seconds=timeout,
+            api_key=api_key,
+        )
+        return jsonify({"ok": True, "categories": categories})
+    except (FreshdeskApiError, FreshdeskRateLimitError) as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 502
+    except Exception as exc:  # noqa: BLE001
+        return jsonify({"ok": False, "error": str(exc)}), 500
+
+
+# --------------------------------------------------------------------------- #
+#  Internal: resolve config from closures
+# --------------------------------------------------------------------------- #
+def _resolve_env_values() -> dict[str, Any]:
+    """Build Freshdesk config from env values injected into the blueprint."""
+    on_get_env = _h.get("on_get_env")
+    if callable(on_get_env):
+        result = on_get_env() or {}
+        return result if isinstance(result, dict) else {}
+    return {}
+
+
+# --------------------------------------------------------------------------- #
+#  Registration
+# --------------------------------------------------------------------------- #
+def register_freshdesk_viewer_blueprint(app, **helpers):
+    """Register the Freshdesk viewer blueprint.
+
+    Parameters
+    ----------
+    app
+        The Flask application.
+    **helpers
+        Keyword pairs whose values are callables or values defined inside
+        ``create_web_app``. Recognised keys:
+        - ``current_user`` – callable, returns the logged-in web user dict
+        - ``selected_guild`` – callable, returns the active guild dict (or {})
+        - ``require_selected_guild_redirect`` – callable, returns redirect or None
+        - ``render_page`` – callable(title, body, email, is_admin) -> Response
+        - ``on_get_env`` – callable, returns dict of env values for Freshdesk
+    """
+    global _h
+    _h = {
+        "current_user": helpers.get("current_user"),
+        "selected_guild": helpers.get("selected_guild"),
+        "require_selected_guild_redirect": helpers.get("require_selected_guild_redirect"),
+        "render_page": helpers.get("render_page"),
+        "on_get_env": helpers.get("on_get_env"),
+    }
+    app.register_blueprint(bp)

--- a/tests/test_freshdesk_api.py
+++ b/tests/test_freshdesk_api.py
@@ -1,0 +1,268 @@
+"""Tests for app/freshdesk_api.py — read-only Freshdesk API client."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.freshdesk_api import (
+    FreshdeskApiError,
+    FreshdeskRateLimitError,
+    clean_freshdesk_text,
+    fetch_freshdesk_ticket,
+    list_freshdesk_solution_categories,
+    list_freshdesk_ticket_fields,
+    search_freshdesk_tickets,
+    build_freshdesk_config,
+    freshdesk_configured,
+    _build_headers,
+    _check_rate_limit,
+    FRESHDESK_ENV_KEYS,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  clean_freshdesk_text
+# --------------------------------------------------------------------------- #
+def test_clean_freshdesk_text_strips_html():
+    assert clean_freshdesk_text("<p>Hello <b>world</b></p>") == "Hello world"
+
+
+def test_clean_freshdesk_text_decodes_entities():
+    assert clean_freshdesk_text("a &amp; b &lt; c") == "a & b < c"
+
+
+def test_clean_freshdesk_text_empty():
+    assert clean_freshdesk_text(None) == ""
+    assert clean_freshdesk_text(12345) == "12345"
+
+
+# --------------------------------------------------------------------------- #
+#  _build_headers
+# --------------------------------------------------------------------------- #
+def test_build_headers_without_api_key():
+    headers = _build_headers("")
+    assert "Authorization" not in headers
+    assert headers["Accept"] == "application/json"
+
+
+def test_build_headers_with_api_key():
+    headers = _build_headers("secret123")
+    assert headers["Authorization"].startswith("Basic ")
+
+
+# --------------------------------------------------------------------------- #
+#  _check_rate_limit
+# --------------------------------------------------------------------------- #
+def _mock_response(status_code):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = {}
+    return resp
+
+
+def test_check_rate_limit_429():
+    resp = _mock_response(429)
+    with pytest.raises(FreshdeskRateLimitError):
+        _check_rate_limit(resp, "test")
+
+
+def test_check_rate_limit_401():
+    resp = _mock_response(401)
+    with pytest.raises(FreshdeskApiError):
+        _check_rate_limit(resp, "test")
+
+
+def test_check_rate_limit_500():
+    resp = _mock_response(500)
+    with pytest.raises(FreshdeskApiError):
+        _check_rate_limit(resp, "test")
+
+
+def test_check_rate_limit_ok():
+    resp = _mock_response(200)
+    # Should not raise
+    _check_rate_limit(resp, "test")
+
+
+# --------------------------------------------------------------------------- #
+#  search_freshdesk_tickets
+# --------------------------------------------------------------------------- #
+@patch("app.freshdesk_api.requests.get")
+def test_search_tickets_success(mock_get):
+    mock_get.return_value = MagicMock(
+        status_code=200,
+        json=lambda: {
+            "results": [
+                {"id": 1, "subject": "Ticket 1", "status": 2, "priority": 3, "ticket_type": "Question", "created_at": "2025-01-01", "updated_at": "2025-01-02"},
+                {"id": 2, "subject": "Ticket 2", "status": 2, "priority": 2, "ticket_type": "Bug", "created_at": "2025-01-03", "updated_at": "2025-01-04"},
+            ]
+        },
+    )
+    tickets = search_freshdesk_tickets(base_url="https://test.freshdesk.com", query="status:2", api_key="key")
+    assert len(tickets) == 2
+    assert tickets[0]["id"] == 1
+    assert tickets[0]["subject"] == "Ticket 1"
+    assert tickets[0]["url"] == "https://test.freshdesk.com/helpdesk/tickets/1"
+
+
+@patch("app.freshdesk_api.requests.get")
+def test_search_tickets_empty(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: {"results": []})
+    tickets = search_freshdesk_tickets(base_url="https://test.freshdesk.com", query="nothing", api_key="key")
+    assert tickets == []
+
+
+@patch("app.freshdesk_api.requests.get")
+def test_search_tickets_rate_limit(mock_get):
+    mock_get.return_value = _mock_response(429)
+    with pytest.raises(FreshdeskRateLimitError):
+        search_freshdesk_tickets(base_url="https://test.freshdesk.com", query="x", api_key="key")
+
+
+@patch("app.freshdesk_api.requests.get")
+def test_search_tickets_no_api_key(mock_get):
+    """Should work without API key (public search endpoint may allow it)."""
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: {"results": []})
+    tickets = search_freshdesk_tickets(base_url="https://test.freshdesk.com", query="test", api_key="")
+    assert tickets == []
+
+
+# --------------------------------------------------------------------------- #
+#  fetch_freshdesk_ticket
+# --------------------------------------------------------------------------- #
+@patch("app.freshdesk_api.requests.get")
+def test_fetch_ticket_success(mock_get):
+    mock_get.return_value = MagicMock(
+        status_code=200,
+        json=lambda: {
+            "id": 42,
+            "subject": "Login issue",
+            "description": "User can't log in",
+            "description_text": "User can't log in<p>Details</p>",
+            "status": 2,
+            "priority": 3,
+            "type": "Bug",
+            "url": "https://test.freshdesk.com/api/v2/tickets/42",
+            "created_at": "2025-01-01",
+            "updated_at": "2025-01-02",
+            "due_by": "2025-01-10",
+            "tags": ["urgent", "login"],
+        },
+    )
+    ticket = fetch_freshdesk_ticket(base_url="https://test.freshdesk.com", ticket_id=42, api_key="key")
+    assert ticket["id"] == 42
+    assert ticket["subject"] == "Login issue"
+    assert "Bug" == ticket["type"]
+    assert ticket["status"] == "Open"  # status 2 -> Open
+    assert ticket["priority"] == "High"  # priority 3 -> High
+    assert ticket["tags"] == ["urgent", "login"]
+
+
+@patch("app.freshdesk_api.requests.get")
+def test_fetch_ticket_not_found(mock_get):
+    mock_get.return_value = MagicMock(status_code=404, json=lambda: {"error": "Not found"})
+    with pytest.raises(FreshdeskApiError):
+        fetch_freshdesk_ticket(base_url="https://test.freshdesk.com", ticket_id=999, api_key="key")
+
+
+@patch("app.freshdesk_api.requests.get")
+def test_fetch_ticket_api_error(mock_get):
+    mock_get.return_value = _mock_response(500)
+    with pytest.raises(FreshdeskApiError):
+        fetch_freshdesk_ticket(base_url="https://test.freshdesk.com", ticket_id=1, api_key="key")
+
+
+# --------------------------------------------------------------------------- #
+#  list_freshdesk_solution_categories
+# --------------------------------------------------------------------------- #
+@patch("app.freshdesk_api.requests.get")
+def test_list_categories_success(mock_get):
+    mock_get.return_value = MagicMock(
+        status_code=200,
+        json=lambda: [
+            {"id": 1, "name": "Getting Started", "description": "Intro docs"},
+            {"id": 2, "name": "Troubleshooting", "description": "Fix guides"},
+        ],
+    )
+    cats = list_freshdesk_solution_categories(base_url="https://test.freshdesk.com", api_key="key")
+    assert len(cats) == 2
+    assert cats[0]["name"] == "Getting Started"
+    assert cats[0]["id"] == 1
+    assert cats[0]["url"] == "https://test.freshdesk.com/solutions/categories/1"
+
+
+@patch("app.freshdesk_api.requests.get")
+def test_list_categories_empty(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: [])
+    cats = list_freshdesk_solution_categories(base_url="https://test.freshdesk.com", api_key="key")
+    assert cats == []
+
+
+# --------------------------------------------------------------------------- #
+#  list_freshdesk_ticket_fields
+# --------------------------------------------------------------------------- #
+@patch("app.freshdesk_api.requests.get")
+def test_list_ticket_fields_success(mock_get):
+    mock_get.return_value = MagicMock(
+        status_code=200,
+        json=lambda: [
+            {"name": "subject", "label": "Subject", "type": "default_subject"},
+            {"name": "status", "label": "Status", "type": "default_status"},
+        ],
+    )
+    fields = list_freshdesk_ticket_fields(base_url="https://test.freshdesk.com", api_key="key")
+    assert len(fields) == 2
+    assert fields[0]["name"] == "subject"
+    assert fields[0]["label"] == "Subject"
+
+
+# --------------------------------------------------------------------------- #
+#  Config helpers
+# --------------------------------------------------------------------------- #
+def test_build_freshdesk_config():
+    config = build_freshdesk_config({
+        "FRESHDESK_BASE_URL": "https://support.example.com",
+        "FRESHDESK_API_KEY": "secret_key",
+        "FRESHDESK_REQUEST_TIMEOUT_SECONDS": "30",
+    })
+    assert config["base_url"] == "https://support.example.com"
+    assert config["api_key"] == "secret_key"
+    assert config["timeout"] == 30
+
+
+def test_build_freshdesk_config_defaults():
+    config = build_freshdesk_config({})
+    assert config["base_url"] == ""
+    assert config["api_key"] == ""
+    assert config["timeout"] == 15
+
+
+def test_build_freshdesk_config_timeout_minimum():
+    config = build_freshdesk_config({"FRESHDESK_REQUEST_TIMEOUT_SECONDS": "1"})
+    assert config["timeout"] == 15  # falls back to 15
+
+
+def test_build_freshdesk_config_bad_timeout():
+    config = build_freshdesk_config({"FRESHDESK_REQUEST_TIMEOUT_SECONDS": "notanumber"})
+    assert config["timeout"] == 15
+
+
+def test_freshdesk_configured_with_key():
+    config = {"base_url": "https://example.com", "api_key": "key"}
+    assert freshdesk_configured(config) is True
+
+
+def test_freshdesk_configured_no_url():
+    assert freshdesk_configured({"base_url": "", "api_key": "key"}) is False
+
+
+def test_freshdesk_configured_no_key():
+    assert freshdesk_configured({"base_url": "https://example.com", "api_key": ""}) is False
+
+
+def test_freshdesk_env_keys():
+    assert "FRESHDESK_BASE_URL" in FRESHDESK_ENV_KEYS
+    assert "FRESHDESK_API_KEY" in FRESHDESK_ENV_KEYS
+    assert "FRESHDESK_REQUEST_TIMEOUT_SECONDS" in FRESHDESK_ENV_KEYS

--- a/web_admin.py
+++ b/web_admin.py
@@ -58,11 +58,20 @@ from app.uptime_kuma_admin import (
     update_monitor,
 )
 from app.web_audit import should_log_web_audit_event
+from app.freshdesk_api import (
+    FreshdeskApiError,
+    FreshdeskRateLimitError,
+    fetch_freshdesk_ticket,
+    list_freshdesk_solution_categories,
+    list_freshdesk_ticket_fields,
+    search_freshdesk_tickets,
+)
 from app.web_discourse import (
     process_discourse_submission,
     render_discourse_body,
 )
 from app.web_discourse_routes import register_discourse_viewer_blueprint
+from app.web_freshdesk_routes import register_freshdesk_viewer_blueprint
 from app.web_guild_settings import process_guild_settings_submission, render_guild_settings_body
 from app.web_honeypot import process_honeypot_submission, render_honeypot_body
 from app.web_members import process_member_action_submission, render_members_body
@@ -164,6 +173,7 @@ INT_KEYS = {
     "GUILD_ID",
     "BOT_LOG_CHANNEL_ID",
     "FORUM_MAX_RESULTS",
+    "FRESHDESK_REQUEST_TIMEOUT_SECONDS",
     "DOCS_MAX_RESULTS_PER_SITE",
     "DOCS_INDEX_TTL_SECONDS",
     "SEARCH_RESPONSE_MAX_CHARS",
@@ -199,6 +209,8 @@ SENSITIVE_KEYS = {
     "WEB_ADMIN_DEFAULT_PASSWORD",
     "WEB_ADMIN_SESSION_SECRET",
     "UPTIME_STATUS_API_KEY",
+    "FRESHDESK_API_KEY",
+    "DISCOURSE_API_KEY",
 }
 FALLBACK_PROTECTED_ENV_KEYS = SENSITIVE_KEYS | {"WEB_ENV_FILE"}
 
@@ -298,6 +310,21 @@ ENV_FIELDS = [
     ),
     ("FORUM_BASE_URL", "Forum Base URL", "GL.iNet forum root URL."),
     ("FORUM_MAX_RESULTS", "Forum Max Results", "Max forum links returned per search."),
+    (
+        "FRESHDESK_BASE_URL",
+        "Freshdesk Base URL",
+        "GL.iNet Freshdesk helpdesk root URL (e.g. https://support.gl-inet.com).",
+    ),
+    (
+        "FRESHDESK_API_KEY",
+        "Freshdesk API Key",
+        "API key for read-only Freshdesk ticket search (never committed — use .env).",
+    ),
+    (
+        "FRESHDESK_REQUEST_TIMEOUT_SECONDS",
+        "Freshdesk Request Timeout",
+        "HTTP timeout in seconds for Freshdesk API calls.",
+    ),
     (
         "DOCS_MAX_RESULTS_PER_SITE",
         "Docs Max/Site",
@@ -2772,6 +2799,7 @@ def _render_layout(
                 <option value="{{ url_for('members_page') }}">Members</option>
                 <option value="{{ url_for('discourse_page') }}">Discourse</option>
                 <option value="{{ url_for('discourse_viewer.discourse_viewer_page') }}">Forum Viewer</option>
+                <option value="{{ url_for('freshdesk_viewer.freshdesk_viewer_page') }}">Freshdesk</option>
                 <option value="{{ url_for('actions_page') }}">Action History</option>
                 <option value="{{ url_for('reddit_feeds') }}">Reddit Feeds</option>
                 <option value="{{ url_for('service_monitors_page') }}">Service Monitors</option>
@@ -2793,6 +2821,7 @@ def _render_layout(
                 <option value="{{ url_for('members_page') }}">Members</option>
                 <option value="{{ url_for('discourse_page') }}">Discourse</option>
                 <option value="{{ url_for('discourse_viewer.discourse_viewer_page') }}">Forum Viewer</option>
+                <option value="{{ url_for('freshdesk_viewer.freshdesk_viewer_page') }}">Freshdesk</option>
                 <option value="{{ url_for('actions_page') }}">Action History</option>
                 <option value="{{ url_for('reddit_feeds') }}">Reddit Feeds</option>
                 <option value="{{ url_for('service_monitors_page') }}">Service Monitors</option>
@@ -2932,6 +2961,8 @@ def _render_layout(
             <option value="{{ url_for('honeypot_page') }}">Honeypot</option>
             <option value="{{ url_for('members_page') }}">Members</option>
             <option value="{{ url_for('discourse_page') }}">Discourse</option>
+            <option value="{{ url_for('discourse_viewer.discourse_viewer_page') }}">Forum Viewer</option>
+            <option value="{{ url_for('freshdesk_viewer.freshdesk_viewer_page') }}">Freshdesk</option>
             <option value="{{ url_for('actions_page') }}">Action History</option>
             <option value="{{ url_for('reddit_feeds') }}">Reddit Feeds</option>
             <option value="{{ url_for('service_monitors_page') }}">Service Monitors</option>
@@ -3549,6 +3580,7 @@ def create_web_app(
             "members_page": "Members",
             "discourse_page": "Discourse",
             "discourse_viewer_page": "Forum Viewer",
+            "freshdesk_viewer_page": "Freshdesk",
             "uptime_kuma_page": "Uptime Kuma",
             "command_status": "Command Status",
             "command_permissions": "Command Permissions",
@@ -4620,6 +4652,12 @@ def create_web_app(
                 "Control the forum URL, API key usage, profile identity, and guild-scoped Discourse feature toggles.",
                 url_for("discourse_page"),
                 "Open Discourse",
+            ),
+            build_dashboard_card(
+                "Freshdesk",
+                "Read-only viewer for GL.iNet support tickets — search and browse Freshdesk tickets without modifications.",
+                url_for("freshdesk_viewer.freshdesk_viewer_page"),
+                "Open Freshdesk",
             ),
             build_dashboard_card(
                 "Bot Profile",
@@ -8454,6 +8492,24 @@ def create_web_app(
         require_selected_guild_redirect=_require_selected_guild_redirect,
         render_page=_render_page,
         get_guild_settings=on_get_guild_settings,
+    )
+
+    # Register Freshdesk Ticket Viewer blueprint (read-only, app/web_freshdesk_routes.py)
+    def _on_get_freshdesk_env():
+        env_vals = _load_effective_env_values(env_file, fallback_env_file)
+        return {
+            "FRESHDESK_BASE_URL": env_vals.get("FRESHDESK_BASE_URL", ""),
+            "FRESHDESK_API_KEY": env_vals.get("FRESHDESK_API_KEY", ""),
+            "FRESHDESK_REQUEST_TIMEOUT_SECONDS": env_vals.get("FRESHDESK_REQUEST_TIMEOUT_SECONDS", "15"),
+        }
+
+    register_freshdesk_viewer_blueprint(
+        app,
+        current_user=_current_user,
+        selected_guild=_selected_guild,
+        require_selected_guild_redirect=_require_selected_guild_redirect,
+        render_page=_render_page,
+        on_get_env=_on_get_freshdesk_env,
     )
 
     @app.route("/admin/settings", methods=["GET", "POST"])


### PR DESCRIPTION
Read-only Freshdesk ticket viewer — no write endpoints implemented.

**Files:**
-  — Freshdesk API client (search, view, list categories)
-  — web-side config + HTML body builders
-  — Flask Blueprint with 4 routes
-  — register blueprint, env vars, nav links, dashboard card
-  — 27 tests, all passing

**Routes:**
-  — main viewer page
-  — ticket search
-  — ticket detail
-  — API endpoint for category listing

**Security:**
-  added to SENSITIVE_KEYS
- Read-only by design (no create/update/delete endpoints)
- All API errors caught and surfaced as user-friendly messages