### PR TITLE
fix: include web admin display name in audit labels

### DIFF
--- a/app/feed_web_callbacks.py
+++ b/app/feed_web_callbacks.py
@@ -98,13 +98,13 @@ class FeedWebCallbacks:
             self.logger.exception("Failed to build Reddit feeds payload for web admin")
             return {"ok": False, "error": "Unexpected error while loading Reddit feeds."}
 
-    def run_web_manage_reddit_feeds(self, payload: dict, actor_email: str, guild_id: int):
+    def run_web_manage_reddit_feeds(self, payload: dict, actor_email: str, guild_id: int, actor_display_name: str = ""):
         if not isinstance(payload, dict):
             return {"ok": False, "error": "Invalid Reddit feed payload."}
 
         action = str(payload.get("action") or "").strip().lower()
         safe_guild_id = self.normalize_target_guild_id(guild_id)
-        audit_actor = self.build_web_actor_audit_label(actor_email)
+        audit_actor = self.build_web_actor_audit_label(actor_email, actor_display_name)
         try:
             if action == "add":
                 subreddit = str(payload.get("subreddit") or "")
@@ -173,12 +173,12 @@ class FeedWebCallbacks:
             self.logger.exception("Failed to build Reddit auto-responds payload for web admin")
             return {"ok": False, "error": "Unexpected error while loading Reddit auto-responds."}
 
-    def run_web_manage_reddit_auto_responds(self, payload: dict, actor_email: str, guild_id: int):
+    def run_web_manage_reddit_auto_responds(self, payload: dict, actor_email: str, guild_id: int, actor_display_name: str = ""):
         if not isinstance(payload, dict):
             return {"ok": False, "error": "Invalid Reddit auto-respond payload."}
         action = str(payload.get("action") or "").strip().lower()
         safe_guild_id = self.normalize_target_guild_id(guild_id)
-        audit_actor = self.build_web_actor_audit_label(actor_email)
+        audit_actor = self.build_web_actor_audit_label(actor_email, actor_display_name)
         try:
             if action == "add":
                 subreddit = str(payload.get("subreddit") or "")
@@ -278,12 +278,12 @@ class FeedWebCallbacks:
             self.logger.exception("Failed to build YouTube subscriptions payload for web admin")
             return {"ok": False, "error": "Unexpected error while loading YouTube subscriptions."}
 
-    def run_web_manage_youtube_subscriptions(self, payload: dict, actor_email: str, guild_id: int):
+    def run_web_manage_youtube_subscriptions(self, payload: dict, actor_email: str, guild_id: int, actor_display_name: str = ""):
         if not isinstance(payload, dict):
             return {"ok": False, "error": "Invalid YouTube subscription payload."}
         action = str(payload.get("action") or "").strip().lower()
         safe_guild_id = self.normalize_target_guild_id(guild_id)
-        audit_actor = self.build_web_actor_audit_label(actor_email)
+        audit_actor = self.build_web_actor_audit_label(actor_email, actor_display_name)
         try:
             if action == "add":
                 source_url = str(payload.get("source_url") or "").strip()
@@ -399,12 +399,12 @@ class FeedWebCallbacks:
             self.logger.exception("Failed to build LinkedIn subscriptions payload for web admin")
             return {"ok": False, "error": "Unexpected error while loading LinkedIn subscriptions."}
 
-    def run_web_manage_linkedin_subscriptions(self, payload: dict, actor_email: str, guild_id: int):
+    def run_web_manage_linkedin_subscriptions(self, payload: dict, actor_email: str, guild_id: int, actor_display_name: str = ""):
         if not isinstance(payload, dict):
             return {"ok": False, "error": "Invalid LinkedIn subscription payload."}
         action = str(payload.get("action") or "").strip().lower()
         safe_guild_id = self.normalize_target_guild_id(guild_id)
-        audit_actor = self.build_web_actor_audit_label(actor_email)
+        audit_actor = self.build_web_actor_audit_label(actor_email, actor_display_name)
         try:
             if action == "add":
                 source_url = str(payload.get("source_url") or "").strip()
@@ -523,12 +523,12 @@ class FeedWebCallbacks:
                 "error": "Unexpected error while loading GL.iNet beta program subscriptions.",
             }
 
-    def run_web_manage_beta_program_subscriptions(self, payload: dict, actor_email: str, guild_id: int):
+    def run_web_manage_beta_program_subscriptions(self, payload: dict, actor_email: str, guild_id: int, actor_display_name: str = ""):
         if not isinstance(payload, dict):
             return {"ok": False, "error": "Invalid GL.iNet beta program payload."}
         action = str(payload.get("action") or "").strip().lower()
         safe_guild_id = self.normalize_target_guild_id(guild_id)
-        audit_actor = self.build_web_actor_audit_label(actor_email)
+        audit_actor = self.build_web_actor_audit_label(actor_email, actor_display_name)
         try:
             if action == "add":
                 target_channel_id = int(str(payload.get("channel_id") or "0").strip())

--- a/app/guild_state.py
+++ b/app/guild_state.py
@@ -118,20 +118,22 @@ class GuildStateManager:
             "updated_by_email": "",
         }
 
-    def build_web_actor_audit_label(self, actor_email: str):
-        normalized = str(actor_email or "").strip().lower()
-        if not normalized:
+    def build_web_actor_audit_label(self, actor_email: str, display_name: str = ""):
+        normalized_email = str(actor_email or "").strip().lower()
+        normalized_name = str(display_name or "").strip()
+        if not normalized_email:
             return "web_user:unknown"
         salt = (self.audit_hash_secret or "glinet-web-audit-label").encode("utf-8")
         digest = hashlib.scrypt(
-            normalized.encode("utf-8"),
+            normalized_email.encode("utf-8"),
             salt=salt,
             n=2**14,
             r=8,
             p=1,
             dklen=12,
         ).hex()
-        return f"web_user:{digest}"
+        label = normalized_name or normalized_email.split("@")[0]
+        return f"web_admin:{label} (web_user:{digest})"
 
     def _guild_settings_columns(self, conn):
         return {str(row["name"]) for row in conn.execute("PRAGMA table_info(guild_settings)").fetchall()}

--- a/bot.py
+++ b/bot.py
@@ -2545,8 +2545,8 @@ def default_guild_settings():
     return guild_state_manager.default_guild_settings()
 
 
-def build_web_actor_audit_label(actor_email: str):
-    return guild_state_manager.build_web_actor_audit_label(actor_email)
+def build_web_actor_audit_label(actor_email: str, display_name: str = ""):
+    return guild_state_manager.build_web_actor_audit_label(actor_email, display_name)
 
 
 def load_guild_settings(guild_id: int | None = None):

--- a/tests/test_guild_state.py
+++ b/tests/test_guild_state.py
@@ -48,8 +48,28 @@ def test_build_web_actor_audit_label_is_stable_and_hides_email():
     second = manager.build_web_actor_audit_label("user@example.com")
 
     assert first == second
-    assert first.startswith("web_user:")
+    assert "web_admin:" in first
+    assert "web_user:" in first
     assert "example.com" not in first
+
+
+def test_build_web_actor_audit_label_includes_display_name():
+    manager = build_manager()
+
+    label = manager.build_web_actor_audit_label("user@example.com", "Alice")
+
+    assert label.startswith("web_admin:Alice")
+    assert "web_user:" in label
+    assert "example.com" not in label
+
+
+def test_build_web_actor_audit_label_falls_back_to_email_local_part():
+    manager = build_manager()
+
+    label = manager.build_web_actor_audit_label("user@example.com")
+
+    assert label.startswith("web_admin:user")
+    assert "web_user:" in label
 
 
 def test_normalize_activity_timestamp_keeps_utc():

--- a/tests/test_web_admin.py
+++ b/tests/test_web_admin.py
@@ -377,7 +377,7 @@ def _make_app(tmp_path: Path):
     def get_reddit_feeds(guild_id):
         return {"ok": True, "feeds": [dict(item) for item in reddit_feeds_state if int(item["guild_id"]) == int(guild_id)]}
 
-    def manage_reddit_feeds(payload, actor_email, guild_id):
+    def manage_reddit_feeds(payload, actor_email, guild_id, actor_display_name=""):
         action = str(payload.get("action") or "").strip().lower()
         safe_guild_id = int(guild_id)
         if action == "add":
@@ -454,7 +454,7 @@ def _make_app(tmp_path: Path):
     def get_youtube_subscriptions(guild_id):
         return {"ok": True, "subscriptions": [dict(item) for item in youtube_subscriptions_state if int(item["guild_id"]) == int(guild_id)]}
 
-    def manage_youtube_subscriptions(payload, actor_email, guild_id):
+    def manage_youtube_subscriptions(payload, actor_email, guild_id, actor_display_name=""):
         action = str(payload.get("action") or "").strip().lower()
         safe_guild_id = int(guild_id)
         if action == "edit":
@@ -520,7 +520,7 @@ def _make_app(tmp_path: Path):
     def get_linkedin_subscriptions(guild_id):
         return {"ok": True, "subscriptions": [dict(item) for item in linkedin_subscriptions_state if int(item["guild_id"]) == int(guild_id)]}
 
-    def manage_linkedin_subscriptions(payload, actor_email, guild_id):
+    def manage_linkedin_subscriptions(payload, actor_email, guild_id, actor_display_name=""):
         action = str(payload.get("action") or "").strip().lower()
         safe_guild_id = int(guild_id)
         if action == "edit":

--- a/web_admin.py
+++ b/web_admin.py
@@ -6028,7 +6028,7 @@ def create_web_app(
                     callback_payload = None
 
                 if callback_payload is not None:
-                    response = on_manage_reddit_feeds(callback_payload, user["email"], selected_guild_id)
+                    response = on_manage_reddit_feeds(callback_payload, user["email"], selected_guild_id, user.get("display_name", ""))
                     if not isinstance(response, dict):
                         flash("Invalid response from Reddit feed handler.", "error")
                     elif response.get("ok"):
@@ -6244,7 +6244,7 @@ def create_web_app(
                     callback_payload = None
 
                 if callback_payload is not None:
-                    response = on_manage_reddit_auto_responds(callback_payload, user["email"], selected_guild_id)
+                    response = on_manage_reddit_auto_responds(callback_payload, user["email"], selected_guild_id, user.get("display_name", ""))
                     if not isinstance(response, dict):
                         flash("Invalid response from auto-respond handler.", "error")
                     elif response.get("ok"):
@@ -6427,7 +6427,7 @@ def create_web_app(
                     callback_payload = None
 
                 if callback_payload is not None:
-                    response = on_manage_youtube_subscriptions(callback_payload, user["email"], selected_guild_id)
+                    response = on_manage_youtube_subscriptions(callback_payload, user["email"], selected_guild_id, user.get("display_name", ""))
                     if not isinstance(response, dict):
                         flash("Invalid response from YouTube subscription handler.", "error")
                     elif response.get("ok"):
@@ -6618,7 +6618,7 @@ def create_web_app(
                     callback_payload = None
 
                 if callback_payload is not None:
-                    response = on_manage_linkedin_subscriptions(callback_payload, user["email"], selected_guild_id)
+                    response = on_manage_linkedin_subscriptions(callback_payload, user["email"], selected_guild_id, user.get("display_name", ""))
                     if not isinstance(response, dict):
                         flash("Invalid response from LinkedIn subscription handler.", "error")
                     elif response.get("ok"):
@@ -6794,7 +6794,7 @@ def create_web_app(
                     callback_payload = None
 
                 if callback_payload is not None:
-                    response = on_manage_beta_program_subscriptions(callback_payload, user["email"], selected_guild_id)
+                    response = on_manage_beta_program_subscriptions(callback_payload, user["email"], selected_guild_id, user.get("display_name", ""))
                     if not isinstance(response, dict):
                         flash("Invalid response from GL.iNet beta program handler.", "error")
                     elif response.get("ok"):


### PR DESCRIPTION
Changes build_web_actor_audit_label to include the admin display name instead of just showing a hashed email. The audit log in the web admin UI now shows human-readable moderator names.