### PR TITLE
feat: add Translate to English message context menu command

### DIFF
--- a/app/translate.py
+++ b/app/translate.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import NamedTuple
+
+logger = logging.getLogger("invite_bot.translate")
+
+LANGUAGE_NAMES: dict[str, str] = {
+    "af": "Afrikaans",
+    "sq": "Albanian",
+    "am": "Amharic",
+    "ar": "Arabic",
+    "hy": "Armenian",
+    "az": "Azerbaijani",
+    "eu": "Basque",
+    "be": "Belarusian",
+    "bn": "Bengali",
+    "bs": "Bosnian",
+    "bg": "Bulgarian",
+    "ca": "Catalan",
+    "ceb": "Cebuano",
+    "ny": "Chichewa",
+    "zh": "Chinese (Simplified)",
+    "zh-cn": "Chinese (Simplified)",
+    "zh-tw": "Chinese (Traditional)",
+    "co": "Corsican",
+    "hr": "Croatian",
+    "cs": "Czech",
+    "da": "Danish",
+    "nl": "Dutch",
+    "en": "English",
+    "eo": "Esperanto",
+    "et": "Estonian",
+    "tl": "Filipino",
+    "fi": "Finnish",
+    "fr": "French",
+    "fy": "Frisian",
+    "gl": "Galician",
+    "ka": "Georgian",
+    "de": "German",
+    "el": "Greek",
+    "gu": "Gujarati",
+    "ht": "Haitian Creole",
+    "ha": "Hausa",
+    "haw": "Hawaiian",
+    "iw": "Hebrew",
+    "he": "Hebrew",
+    "hi": "Hindi",
+    "hmn": "Hmong",
+    "hu": "Hungarian",
+    "is": "Icelandic",
+    "ig": "Igbo",
+    "id": "Indonesian",
+    "ga": "Irish",
+    "it": "Italian",
+    "ja": "Japanese",
+    "jw": "Javanese",
+    "kn": "Kannada",
+    "kk": "Kazakh",
+    "km": "Khmer",
+    "rw": "Kinyarwanda",
+    "ko": "Korean",
+    "ku": "Kurdish",
+    "ky": "Kyrgyz",
+    "lo": "Lao",
+    "la": "Latin",
+    "lv": "Latvian",
+    "lt": "Lithuanian",
+    "lb": "Luxembourgish",
+    "mk": "Macedonian",
+    "mg": "Malagasy",
+    "ms": "Malay",
+    "ml": "Malayalam",
+    "mt": "Maltese",
+    "mi": "Maori",
+    "mr": "Marathi",
+    "mn": "Mongolian",
+    "my": "Myanmar (Burmese)",
+    "ne": "Nepali",
+    "no": "Norwegian",
+    "or": "Odia",
+    "ps": "Pashto",
+    "fa": "Persian",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "pa": "Punjabi",
+    "ro": "Romanian",
+    "ru": "Russian",
+    "sm": "Samoan",
+    "gd": "Scots Gaelic",
+    "sr": "Serbian",
+    "st": "Sesotho",
+    "sn": "Shona",
+    "sd": "Sindhi",
+    "si": "Sinhala",
+    "sk": "Slovak",
+    "sl": "Slovenian",
+    "so": "Somali",
+    "es": "Spanish",
+    "su": "Sundanese",
+    "sw": "Swahili",
+    "sv": "Swedish",
+    "tg": "Tajik",
+    "ta": "Tamil",
+    "tt": "Tatar",
+    "te": "Telugu",
+    "th": "Thai",
+    "tr": "Turkish",
+    "tk": "Turkmen",
+    "uk": "Ukrainian",
+    "ur": "Urdu",
+    "ug": "Uyghur",
+    "uz": "Uzbek",
+    "vi": "Vietnamese",
+    "cy": "Welsh",
+    "xh": "Xhosa",
+    "yi": "Yiddish",
+    "yo": "Yoruba",
+    "zu": "Zulu",
+}
+
+
+class TranslationResult(NamedTuple):
+    text: str
+    source_language: str
+    source_language_name: str
+    target_language: str
+    target_language_name: str
+
+
+def get_language_name(code: str) -> str:
+    normalized = str(code or "").strip().lower()
+    return LANGUAGE_NAMES.get(normalized, normalized.upper() if normalized else "Unknown")
+
+
+def translate_text(
+    text: str,
+    target_lang: str = "en",
+    source_lang: str = "auto",
+    timeout: float = 8.0,
+) -> TranslationResult:
+    clean_text = str(text or "").strip()
+    if not clean_text:
+        raise ValueError("Cannot translate empty text.")
+
+    safe_target = str(target_lang or "en").strip().lower() or "en"
+    safe_source = str(source_lang or "auto").strip().lower() or "auto"
+
+    encoded_query = urllib.parse.quote(clean_text)
+    url = (
+        f"https://translate.googleapis.com/translate_a/single"
+        f"?client=gtx&sl={safe_source}&tl={safe_target}&dt=t&q={encoded_query}"
+    )
+
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Accept": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            raw_data = response.read().decode("utf-8")
+            data = json.loads(raw_data)
+    except urllib.error.HTTPError as exc:
+        logger.error("HTTP error translating text (%s): %s", exc.code, exc)
+        raise RuntimeError(f"Translation service returned error code {exc.code}.") from exc
+    except urllib.error.URLError as exc:
+        logger.error("Connection error translating text: %s", exc)
+        raise RuntimeError("Unable to reach translation service.") from exc
+    except Exception as exc:
+        logger.exception("Unexpected error during translation")
+        raise RuntimeError(f"Translation failed: {exc}") from exc
+
+    if not isinstance(data, list) or not data:
+        raise RuntimeError("Unexpected response structure from translation service.")
+
+    sentences = data[0] if isinstance(data[0], list) else []
+    translated_parts = [
+        str(segment[0])
+        for segment in sentences
+        if isinstance(segment, list) and len(segment) > 0 and segment[0]
+    ]
+    translated_text = "".join(translated_parts).strip()
+
+    detected_code = str(data[2]).strip() if len(data) > 2 and data[2] else safe_source
+
+    return TranslationResult(
+        text=translated_text,
+        source_language=detected_code,
+        source_language_name=get_language_name(detected_code),
+        target_language=safe_target,
+        target_language_name=get_language_name(safe_target),
+    )

--- a/bot.py
+++ b/bot.py
@@ -130,6 +130,7 @@ from app.service_monitor import (
     normalize_service_monitor_targets,
     run_service_monitor_check,
 )
+from app.translate import translate_text
 from app.uptime_status import (
     UptimeStatusAuthError,
     build_uptime_source_config,
@@ -1140,6 +1141,7 @@ COMMAND_PERMISSION_DEFAULTS = {
     "search_iot": COMMAND_PERMISSION_DEFAULT_POLICY_PUBLIC,
     "search_router": COMMAND_PERMISSION_DEFAULT_POLICY_PUBLIC,
     "search_astrowarp": COMMAND_PERMISSION_DEFAULT_POLICY_PUBLIC,
+    "translate_to_english": COMMAND_PERMISSION_DEFAULT_POLICY_PUBLIC,
     "honeypot_create": COMMAND_PERMISSION_DEFAULT_POLICY_ADMINISTRATOR,
     "honeypot_edit": COMMAND_PERMISSION_DEFAULT_POLICY_ADMINISTRATOR,
     "honeypot_list": COMMAND_PERMISSION_DEFAULT_POLICY_ADMINISTRATOR,
@@ -1425,6 +1427,10 @@ COMMAND_PERMISSION_METADATA = {
     "search_astrowarp": {
         "label": "/search_astrowarp, !searchastrowarp",
         "description": "Search AstroWarp docs only.",
+    },
+    "translate_to_english": {
+        "label": "Apps -> Translate to English",
+        "description": "Translate a message to English via message context menu.",
     },
 }
 COMMAND_PERMISSION_POLICY_LABELS = {
@@ -17281,6 +17287,45 @@ async def freshdesk_categories(interaction: discord.Interaction):
     for cat in categories[:15]:
         lines.append(f"- **{cat['name']}** (#{cat['id']}) — {cat['url']}")
     await interaction.followup.send("\n".join(lines), ephemeral=True)
+
+
+@tree.context_menu(name="Translate to English")
+async def translate_to_english_ctx(interaction: discord.Interaction, message: discord.Message):
+    logger.info("Translate to English context menu invoked by %s on message %s", f"{interaction.user} (id: {interaction.user.id})", message.id)
+    if not await ensure_interaction_command_access(interaction, "translate_to_english"):
+        return
+
+    raw_text = str(message.content or "").strip()
+    if not raw_text:
+        await interaction.response.send_message("❌ This message contains no text to translate.", ephemeral=True)
+        return
+
+    await interaction.response.defer(ephemeral=False)
+    try:
+        result = await asyncio.to_thread(translate_text, raw_text, "en", "auto")
+    except Exception as exc:
+        logger.exception("Translation failed for message %s", message.id)
+        await interaction.followup.send(f"❌ Translation failed: {exc}", ephemeral=True)
+        return
+
+    embed = discord.Embed(
+        description=result.text[:4096],
+        color=discord.Color.blue(),
+    )
+    author_name = message.author.display_name
+    author_icon = message.author.display_avatar.url if message.author.display_avatar else None
+    if author_icon:
+        embed.set_author(name=f"{author_name}'s message", icon_url=author_icon, url=message.jump_url)
+    else:
+        embed.set_author(name=f"{author_name}'s message", url=message.jump_url)
+
+    footer_text = f"Translated from {result.source_language_name} ({result.source_language}) to {result.target_language_name}"
+    embed.set_footer(text=footer_text)
+
+    await interaction.followup.send(
+        content=f"🌐 **Translation for {message.author.mention}'s [message]({message.jump_url}):**",
+        embed=embed,
+    )
 
 
 tree.add_command(honeypot_group)

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import os
+import urllib.error
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import discord
+
+os.environ.setdefault("DISCORD_TOKEN", "mock-token-for-tests")
+os.environ.setdefault("GUILD_ID", "123456789")
+os.environ.setdefault("DATA_DIR", "/tmp/bot-test-data")
+
+from app.translate import (
+    TranslationResult,
+    get_language_name,
+    translate_text,
+)
+from bot import translate_to_english_ctx
+
+
+def test_get_language_name():
+    assert get_language_name("fr") == "French"
+    assert get_language_name("zh-cn") == "Chinese (Simplified)"
+    assert get_language_name("es") == "Spanish"
+    assert get_language_name("de") == "German"
+    assert get_language_name("unknown_code") == "UNKNOWN_CODE"
+    assert get_language_name("") == "Unknown"
+
+
+def test_translate_text_empty():
+    with pytest.raises(ValueError, match="Cannot translate empty text"):
+        translate_text("")
+    with pytest.raises(ValueError, match="Cannot translate empty text"):
+        translate_text("   ")
+
+
+def test_translate_text_mocked_success():
+    fake_response = [
+        [["Hello world! ", "Bonjour le monde! ", None, None]],
+        None,
+        "fr",
+    ]
+    raw_bytes = json.dumps(fake_response).encode("utf-8")
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = raw_bytes
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.__exit__.return_value = None
+
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        res = translate_text("Bonjour le monde!", target_lang="en")
+        assert isinstance(res, TranslationResult)
+        assert res.text == "Hello world!"
+        assert res.source_language == "fr"
+        assert res.source_language_name == "French"
+        assert res.target_language == "en"
+        assert res.target_language_name == "English"
+
+
+def test_translate_text_network_error():
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("Network down")):
+        with pytest.raises(RuntimeError, match="Unable to reach translation service"):
+            translate_text("Hello")
+
+
+def test_translate_context_menu_empty_message():
+    async def _run():
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.user = MagicMock(id=1234, spec=discord.Member)
+        interaction.response.send_message = AsyncMock()
+
+        message = MagicMock(spec=discord.Message)
+        message.content = ""
+
+        with patch("bot.ensure_interaction_command_access", AsyncMock(return_value=True)):
+            await translate_to_english_ctx.callback(interaction, message)
+            interaction.response.send_message.assert_called_once()
+            assert "contains no text" in interaction.response.send_message.call_args[0][0]
+
+    asyncio.run(_run())
+
+
+def test_translate_context_menu_success():
+    async def _run():
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.user = MagicMock(id=1234, spec=discord.Member)
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+
+        message = MagicMock(spec=discord.Message)
+        message.id = 99887766
+        message.content = "Bonjour"
+        message.jump_url = "https://discord.com/channels/1/2/3"
+        message.author = MagicMock(spec=discord.Member)
+        message.author.display_name = "Pierre"
+        message.author.mention = "<@5555>"
+        message.author.display_avatar.url = "https://cdn.discordapp.com/avatar.png"
+
+        fake_result = TranslationResult(
+            text="Hello",
+            source_language="fr",
+            source_language_name="French",
+            target_language="en",
+            target_language_name="English",
+        )
+
+        with patch("bot.ensure_interaction_command_access", AsyncMock(return_value=True)), \
+             patch("bot.translate_text", return_value=fake_result):
+            await translate_to_english_ctx.callback(interaction, message)
+            interaction.response.defer.assert_called_once_with(ephemeral=False)
+            interaction.followup.send.assert_called_once()
+            call_kwargs = interaction.followup.send.call_args[1]
+            assert "embed" in call_kwargs
+            embed = call_kwargs["embed"]
+            assert embed.description == "Hello"
+            assert "French (fr)" in embed.footer.text
+            assert "https://discord.com/channels/1/2/3" in call_kwargs["content"]
+
+    asyncio.run(_run())


### PR DESCRIPTION
Adds a Discord message context menu command (Right-click message -> Apps -> Translate to English). Translates message text to English, identifies detected source language, and posts the translation publicly in the channel with a jump link to the original message.