### PR TITLE
feat: add flag-reaction auto-translate and dedicated translate channels

### DIFF
--- a/app/translate.py
+++ b/app/translate.py
@@ -132,9 +132,70 @@ class TranslationResult(NamedTuple):
     target_language_name: str
 
 
+FLAG_EMOJI_TO_LANG: dict[str, str] = {
+    "🇺🇸": "en",  # United States -> English
+    "🇬🇧": "en",  # United Kingdom -> English
+    "🇨🇦": "en",  # Canada (default) -> English
+    "🇦🇺": "en",  # Australia -> English
+    "🇮🇪": "en",  # Ireland -> English
+    "🇪🇸": "es",  # Spain -> Spanish
+    "🇲🇽": "es",  # Mexico -> Spanish
+    "🇦🇷": "es",  # Argentina -> Spanish
+    "🇫🇷": "fr",  # France -> French
+    "🇨🇦_qc": "fr",  # Quebec (not standard but tolerated)
+    "🇧🇪": "fr",  # Belgium -> French
+    "🇨🇭": "fr",  # Switzerland (one of) -> French
+    "🇩🇪": "de",  # Germany -> German
+    "🇦🇹": "de",  # Austria -> German
+    "🇮🇹": "it",  # Italy -> Italian
+    "🇵🇹": "pt",  # Portugal -> Portuguese
+    "🇧🇷": "pt",  # Brazil -> Portuguese
+    "🇷🇺": "ru",  # Russia -> Russian
+    "🇨🇳": "zh-cn",  # China -> Simplified Chinese
+    "🇭🇰": "zh-tw",  # Hong Kong -> Traditional Chinese
+    "🇹🇼": "zh-tw",  # Taiwan -> Traditional Chinese
+    "🇯🇵": "ja",  # Japan -> Japanese
+    "🇰🇷": "ko",  # South Korea -> Korean
+    "🇸🇦": "ar",  # Saudi Arabia -> Arabic
+    "🇪🇬": "ar",  # Egypt -> Arabic
+    "🇦🇪": "ar",  # UAE -> Arabic
+    "🇮🇳": "hi",  # India -> Hindi
+    "🇹🇷": "tr",  # Turkey -> Turkish
+    "🇳🇱": "nl",  # Netherlands -> Dutch
+    "🇵🇱": "pl",  # Poland -> Polish
+    "🇸🇪": "sv",  # Sweden -> Swedish
+    "🇳🇴": "no",  # Norway -> Norwegian
+    "🇩🇰": "da",  # Denmark -> Danish
+    "🇫🇮": "fi",  # Finland -> Finnish
+    "🇬🇷": "el",  # Greece -> Greek
+    "🇮🇱": "he",  # Israel -> Hebrew
+    "🇹🇭": "th",  # Thailand -> Thai
+    "🇻🇳": "vi",  # Vietnam -> Vietnamese
+    "🇮🇩": "id",  # Indonesia -> Indonesian
+    "🇲🇾": "ms",  # Malaysia -> Malay
+    "🇵🇭": "tl",  # Philippines -> Filipino/Tagalog
+    "🇺🇦": "uk",  # Ukraine -> Ukrainian
+    "🇨🇿": "cs",  # Czech Republic -> Czech
+    "🇷🇴": "ro",  # Romania -> Romanian
+    "🇭🇺": "hu",  # Hungary -> Hungarian
+    "🇮🇸": "is",  # Iceland -> Icelandic
+    "🇪🇪": "et",  # Estonia -> Estonian
+    "🇱🇻": "lv",  # Latvia -> Latvian
+    "🇱🇹": "lt",  # Lithuania -> Lithuanian
+}
+
+
 def get_language_name(code: str) -> str:
     normalized = str(code or "").strip().lower()
     return LANGUAGE_NAMES.get(normalized, normalized.upper() if normalized else "Unknown")
+
+
+def get_lang_for_flag(emoji: str) -> str | None:
+    """Resolve a country flag emoji to its ISO 639-1 language code, or None if not a known flag."""
+    if not emoji:
+        return None
+    raw = str(emoji).strip()
+    return FLAG_EMOJI_TO_LANG.get(raw)
 
 
 def translate_text(

--- a/app/translate_channels.py
+++ b/app/translate_channels.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+from typing import Any
+
+logger = logging.getLogger("invite_bot.translate_channels")
+
+_CREATE_SQL = """
+CREATE TABLE IF NOT EXISTS auto_translate_channels (
+    guild_id INTEGER NOT NULL,
+    source_channel_id INTEGER NOT NULL,
+    target_channel_id INTEGER NOT NULL,
+    target_language TEXT NOT NULL DEFAULT 'en',
+    source_language TEXT NOT NULL DEFAULT 'auto',
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (guild_id, source_channel_id, target_channel_id, target_language)
+)
+"""
+
+
+class AutoTranslateChannelStore:
+    """Persistence layer for auto-translate channel mappings (source -> target language)."""
+
+    def __init__(self, db_path: str, db_lock: threading.Lock):
+        self.db_path = db_path
+        self.db_lock = db_lock
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        try:
+            conn.execute(_CREATE_SQL)
+            conn.commit()
+        finally:
+            conn.close()
+        logger.info("Auto-translate channel store initialized at %s", self.db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path, check_same_thread=False, timeout=10)
+
+    def list_for_guild(self, guild_id: int) -> list[dict[str, Any]]:
+        with self.db_lock:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT guild_id, source_channel_id, target_channel_id, target_language, source_language, enabled
+                    FROM auto_translate_channels
+                    WHERE guild_id = ?
+                    ORDER BY source_channel_id, target_language
+                    """,
+                    (int(guild_id),),
+                ).fetchall()
+            finally:
+                conn.close()
+        return [
+            {
+                "guild_id": row[0],
+                "source_channel_id": row[1],
+                "target_channel_id": row[2],
+                "target_language": row[3],
+                "source_language": row[4],
+                "enabled": bool(row[5]),
+            }
+            for row in rows
+        ]
+
+    def list_active_for_source(self, guild_id: int, source_channel_id: int) -> list[dict[str, Any]]:
+        with self.db_lock:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT guild_id, source_channel_id, target_channel_id, target_language, source_language, enabled
+                    FROM auto_translate_channels
+                    WHERE guild_id = ? AND source_channel_id = ? AND enabled = 1
+                    ORDER BY target_language
+                    """,
+                    (int(guild_id), int(source_channel_id)),
+                ).fetchall()
+            finally:
+                conn.close()
+        return [
+            {
+                "guild_id": row[0],
+                "source_channel_id": row[1],
+                "target_channel_id": row[2],
+                "target_language": row[3],
+                "source_language": row[4],
+                "enabled": bool(row[5]),
+            }
+            for row in rows
+        ]
+
+    def upsert(
+        self,
+        guild_id: int,
+        source_channel_id: int,
+        target_channel_id: int,
+        target_language: str = "en",
+        source_language: str = "auto",
+        enabled: bool = True,
+    ) -> None:
+        with self.db_lock:
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO auto_translate_channels (
+                        guild_id, source_channel_id, target_channel_id, target_language, source_language, enabled, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+                    ON CONFLICT(guild_id, source_channel_id, target_channel_id, target_language) DO UPDATE SET
+                        source_language = excluded.source_language,
+                        enabled = excluded.enabled,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        int(guild_id),
+                        int(source_channel_id),
+                        int(target_channel_id),
+                        str(target_language).strip().lower() or "en",
+                        str(source_language).strip().lower() or "auto",
+                        1 if enabled else 0,
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+    def delete(
+        self,
+        guild_id: int,
+        source_channel_id: int,
+        target_channel_id: int,
+        target_language: str,
+    ) -> bool:
+        with self.db_lock:
+            conn = self._connect()
+            try:
+                cur = conn.execute(
+                    """
+                    DELETE FROM auto_translate_channels
+                    WHERE guild_id = ? AND source_channel_id = ? AND target_channel_id = ? AND target_language = ?
+                    """,
+                    (
+                        int(guild_id),
+                        int(source_channel_id),
+                        int(target_channel_id),
+                        str(target_language).strip().lower(),
+                    ),
+                )
+                conn.commit()
+                return cur.rowcount > 0
+            finally:
+                conn.close()
+
+    def set_enabled(
+        self,
+        guild_id: int,
+        source_channel_id: int,
+        target_channel_id: int,
+        target_language: str,
+        enabled: bool,
+    ) -> bool:
+        with self.db_lock:
+            conn = self._connect()
+            try:
+                cur = conn.execute(
+                    """
+                    UPDATE auto_translate_channels
+                    SET enabled = ?, updated_at = datetime('now')
+                    WHERE guild_id = ? AND source_channel_id = ? AND target_channel_id = ? AND target_language = ?
+                    """,
+                    (
+                        1 if enabled else 0,
+                        int(guild_id),
+                        int(source_channel_id),
+                        int(target_channel_id),
+                        str(target_language).strip().lower(),
+                    ),
+                )
+                conn.commit()
+                return cur.rowcount > 0
+            finally:
+                conn.close()
+
+    def to_json(self, guild_id: int) -> str:
+        return json.dumps(self.list_for_guild(guild_id), indent=2)

--- a/bot.py
+++ b/bot.py
@@ -130,7 +130,8 @@ from app.service_monitor import (
     normalize_service_monitor_targets,
     run_service_monitor_check,
 )
-from app.translate import translate_text
+from app.translate import get_lang_for_flag, translate_text
+from app.translate_channels import AutoTranslateChannelStore
 from app.uptime_status import (
     UptimeStatusAuthError,
     build_uptime_source_config,
@@ -1142,6 +1143,7 @@ COMMAND_PERMISSION_DEFAULTS = {
     "search_router": COMMAND_PERMISSION_DEFAULT_POLICY_PUBLIC,
     "search_astrowarp": COMMAND_PERMISSION_DEFAULT_POLICY_PUBLIC,
     "translate_to_english": COMMAND_PERMISSION_DEFAULT_POLICY_PUBLIC,
+    "translate_channels_manage": COMMAND_PERMISSION_DEFAULT_POLICY_MODERATOR_IDS,
     "honeypot_create": COMMAND_PERMISSION_DEFAULT_POLICY_ADMINISTRATOR,
     "honeypot_edit": COMMAND_PERMISSION_DEFAULT_POLICY_ADMINISTRATOR,
     "honeypot_list": COMMAND_PERMISSION_DEFAULT_POLICY_ADMINISTRATOR,
@@ -1432,6 +1434,10 @@ COMMAND_PERMISSION_METADATA = {
         "label": "Apps -> Translate to English",
         "description": "Translate a message to English via message context menu.",
     },
+    "translate_channels_manage": {
+        "label": "/translate_channels_*",
+        "description": "Moderator: list, add, or remove auto-translate channel mappings.",
+    },
 }
 COMMAND_PERMISSION_POLICY_LABELS = {
     COMMAND_PERMISSION_DEFAULT_POLICY_PUBLIC: "Public (any member)",
@@ -1481,6 +1487,7 @@ command_permissions_lock = threading.Lock()
 command_permissions_cache = {}
 db_lock = threading.RLock()
 db_connection = None
+auto_translate_channel_store: AutoTranslateChannelStore | None = None
 member_activity_recent_prune_marker = ""
 FIRMWARE_CHANNEL_WARNING_COOLDOWN_SECONDS = 3600
 FIRMWARE_NOTIFICATION_ITEM_LIMIT = 12
@@ -12432,7 +12439,10 @@ async def on_ready():
     global service_monitor_task
     global uptime_status_monitor_task
     global member_activity_backfill_task
+    global auto_translate_channel_store
     install_asyncio_exception_logging(asyncio.get_running_loop())
+    if auto_translate_channel_store is None:
+        auto_translate_channel_store = AutoTranslateChannelStore(DB_FILE, db_lock)
     purged_archives = purge_expired_guild_archives()
     if purged_archives:
         logger.info(
@@ -12777,6 +12787,39 @@ async def on_member_update(before: discord.Member, after: discord.Member):
         await send_server_event_log(guild, "member_role_removed", details, actor=actor_label)
 
 
+async def _post_translation_reply(
+    target_channel: discord.abc.MessageableChannel,
+    original_message: discord.Message,
+    result,
+    target_lang: str,
+) -> bool:
+    """Post a translation reply to the given channel as a quoted reply, returning success."""
+    embed = discord.Embed(
+        description=result.text[:4096],
+        color=discord.Color.blue(),
+    )
+    author_name = original_message.author.display_name
+    author_icon = original_message.author.display_avatar.url if original_message.author.display_avatar else None
+    if author_icon:
+        embed.set_author(name=f"{author_name}'s message", icon_url=author_icon, url=original_message.jump_url)
+    else:
+        embed.set_author(name=f"{author_name}'s message", url=original_message.jump_url)
+    embed.set_footer(
+        text=f"Translated from {result.source_language_name} ({result.source_language}) to {result.target_language_name}"
+    )
+    try:
+        await target_channel.send(
+            content=f"🌐 **Translation of {original_message.author.mention}'s [message]({original_message.jump_url}) to {target_lang.upper()}:**",
+            embed=embed,
+            reference=original_message if hasattr(target_channel, "send") else None,
+            mention_author=False,
+        )
+        return True
+    except discord.HTTPException:
+        logger.exception("Failed posting translation reply in channel %s", getattr(target_channel, "id", "?"))
+        return False
+
+
 @bot.event
 async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
     if payload.user_id == (bot.user.id if bot.user else 0):
@@ -12825,6 +12868,36 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
         await member.add_roles(role, reason=f"Reaction role assigned for message {payload.message_id}")
     except Exception:
         logger.exception("Failed to assign reaction role %s to member %s in guild %s", role_id, payload.user_id, guild_id)
+
+    # After reaction-role processing, also try flag-based auto-translation.
+    try:
+        if auto_translate_channel_store is not None:
+            emoji_str = str(payload.emoji) if payload.emoji else ""
+            target_lang = get_lang_for_flag(emoji_str)
+            if target_lang and channel is not None and hasattr(channel, "fetch_message"):
+                try:
+                    target_message = await channel.fetch_message(int(payload.message_id))
+                except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                    target_message = None
+                if target_message is not None:
+                    raw_text = str(getattr(target_message, "content", "") or "").strip()
+                    if raw_text:
+                        try:
+                            result = await asyncio.to_thread(translate_text, raw_text, target_lang, "auto")
+                        except Exception:
+                            logger.exception("Flag-reaction translation failed for message %s -> %s", target_message.id, target_lang)
+                        else:
+                            try:
+                                await _post_translation_reply(channel, target_message, result, target_lang)
+                            except Exception:
+                                logger.exception("Flag-reaction reply failed in channel %s", channel.id)
+                            else:
+                                logger.info(
+                                    "Flag reaction translated message %s -> %s by user %s in guild %s",
+                                    target_message.id, target_lang, payload.user_id, payload.guild_id,
+                                )
+    except Exception:
+        logger.exception("Unexpected error in flag-reaction translation for message %s", payload.message_id)
 
 
 @bot.event
@@ -13072,6 +13145,59 @@ async def on_message(message: discord.Message):
                 guild_id=message.guild.id if message.guild else None,
             ):
                 await message.channel.send(response)
+    # Auto-translate channel bridge: forward any non-trivial message in a
+    # configured source channel to its paired target channel with a translation.
+    if message.guild is not None and message.content and auto_translate_channel_store is not None:
+        try:
+            mappings = auto_translate_channel_store.list_active_for_source(
+                int(message.guild.id),
+                int(message.channel.id),
+            )
+        except Exception:
+            logger.exception("Failed loading auto-translate mappings for channel %s", message.channel.id)
+            mappings = []
+        for mapping in mappings:
+            target_channel_id = int(mapping.get("target_channel_id") or 0)
+            target_language = str(mapping.get("target_language") or "en").strip().lower() or "en"
+            source_language = str(mapping.get("source_language") or "auto").strip().lower() or "auto"
+            if target_channel_id <= 0 or target_channel_id == int(message.channel.id):
+                continue
+            target_channel = message.guild.get_channel(target_channel_id)
+            if target_channel is None or not hasattr(target_channel, "send"):
+                continue
+            raw_text = str(message.content or "").strip()
+            if not raw_text or len(raw_text) > 1900:
+                continue
+            try:
+                result = await asyncio.to_thread(translate_text, raw_text, target_language, source_language)
+            except Exception:
+                logger.exception(
+                    "Auto-translate channel bridge failed: guild=%s src=%s tgt=%s",
+                    message.guild.id, message.channel.id, target_channel_id,
+                )
+                continue
+            embed = discord.Embed(
+                description=result.text[:4096],
+                color=discord.Color.blue(),
+            )
+            author_name = message.author.display_name
+            author_icon = message.author.display_avatar.url if message.author.display_avatar else None
+            if author_icon:
+                embed.set_author(name=f"{author_name} in #{message.channel.name}", icon_url=author_icon, url=message.jump_url)
+            else:
+                embed.set_author(name=f"{author_name} in #{message.channel.name}", url=message.jump_url)
+            embed.set_footer(
+                text=f"Auto-translated from {result.source_language_name} ({result.source_language}) to {result.target_language_name}"
+            )
+            try:
+                await target_channel.send(
+                    content=f"🌐 **{message.author.mention} said in <#{message.channel.id}>:**",
+                    embed=embed,
+                )
+            except discord.Forbidden:
+                logger.warning("Auto-translate bridge: cannot post in %s (missing permissions)", target_channel_id)
+            except discord.HTTPException:
+                logger.exception("Auto-translate bridge: HTTP error posting in %s", target_channel_id)
     await bot.process_commands(message)
 
 
@@ -17331,6 +17457,125 @@ async def translate_to_english_ctx(interaction: discord.Interaction, message: di
 tree.add_command(honeypot_group)
 tree.add_command(honeypot_log_group)
 tree.add_command(honeypot_join_guard_group)
+
+
+@tree.command(
+    name="translate_channels_list",
+    description="List auto-translate channel mappings in this server (admin).",
+)
+async def translate_channels_list(interaction: discord.Interaction):
+    if not await ensure_interaction_command_access(interaction, "translate_channels_manage"):
+        return
+    if interaction.guild is None:
+        await interaction.response.send_message("❌ This command can only be used in a server.", ephemeral=True)
+        return
+    if auto_translate_channel_store is None:
+        await interaction.response.send_message("❌ Auto-translate store not initialized.", ephemeral=True)
+        return
+    mappings = auto_translate_channel_store.list_for_guild(int(interaction.guild.id))
+    if not mappings:
+        await interaction.response.send_message(
+            "ℹ️ No auto-translate channel mappings are configured for this server.",
+            ephemeral=True,
+        )
+        return
+    lines = ["**Auto-Translate Channel Mappings**\n"]
+    for m in mappings:
+        enabled = "🟢" if m.get("enabled") else "⚫"
+        lines.append(
+            f"{enabled} <#{m['source_channel_id']}> → <#{m['target_channel_id']}> "
+            f"({m['source_language']}→**{m['target_language']}**)"
+        )
+    await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+
+@tree.command(
+    name="translate_channels_add",
+    description="Add an auto-translate channel mapping (admin).",
+)
+@app_commands.describe(
+    source_channel="Channel whose messages should be translated",
+    target_channel="Channel to post the translation into",
+    target_language="Target language code (e.g. en, es, fr, de)",
+    source_language="Source language code or 'auto' (default auto)",
+    enabled="Whether the mapping is active (default true)",
+)
+async def translate_channels_add(
+    interaction: discord.Interaction,
+    source_channel: discord.TextChannel,
+    target_channel: discord.TextChannel,
+    target_language: str = "en",
+    source_language: str = "auto",
+    enabled: bool = True,
+):
+    if not await ensure_interaction_command_access(interaction, "translate_channels_manage"):
+        return
+    if interaction.guild is None:
+        await interaction.response.send_message("❌ This command can only be used in a server.", ephemeral=True)
+        return
+    if source_channel.guild.id != interaction.guild.id or target_channel.guild.id != interaction.guild.id:
+        await interaction.response.send_message("❌ Both channels must be in this server.", ephemeral=True)
+        return
+    if source_channel.id == target_channel.id:
+        await interaction.response.send_message("❌ Source and target channels must differ.", ephemeral=True)
+        return
+    if auto_translate_channel_store is None:
+        await interaction.response.send_message("❌ Auto-translate store not initialized.", ephemeral=True)
+        return
+    auto_translate_channel_store.upsert(
+        int(interaction.guild.id),
+        int(source_channel.id),
+        int(target_channel.id),
+        target_language=target_language,
+        source_language=source_language,
+        enabled=enabled,
+    )
+    state = "enabled" if enabled else "disabled"
+    await interaction.response.send_message(
+        f"✅ Auto-translate mapping saved ({state}): "
+        f"<#{source_channel.id}> → <#{target_channel.id}> "
+        f"({source_language}→**{target_language.lower()}**)",
+        ephemeral=True,
+    )
+
+
+@tree.command(
+    name="translate_channels_remove",
+    description="Remove an auto-translate channel mapping (admin).",
+)
+@app_commands.describe(
+    source_channel="Source channel of the mapping",
+    target_channel="Target channel of the mapping",
+    target_language="Target language code (e.g. en, es, fr, de)",
+)
+async def translate_channels_remove(
+    interaction: discord.Interaction,
+    source_channel: discord.TextChannel,
+    target_channel: discord.TextChannel,
+    target_language: str,
+):
+    if not await ensure_interaction_command_access(interaction, "translate_channels_manage"):
+        return
+    if interaction.guild is None:
+        await interaction.response.send_message("❌ This command can only be used in a server.", ephemeral=True)
+        return
+    if auto_translate_channel_store is None:
+        await interaction.response.send_message("❌ Auto-translate store not initialized.", ephemeral=True)
+        return
+    removed = auto_translate_channel_store.delete(
+        int(interaction.guild.id),
+        int(source_channel.id),
+        int(target_channel.id),
+        target_language,
+    )
+    if removed:
+        await interaction.response.send_message(
+            f"✅ Removed auto-translate mapping: "
+            f"<#{source_channel.id}> → <#{target_channel.id}> ({target_language.lower()})",
+            ephemeral=True,
+        )
+    else:
+        await interaction.response.send_message("ℹ️ No matching auto-translate mapping found.", ephemeral=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -16,6 +16,8 @@ os.environ.setdefault("DATA_DIR", "/tmp/bot-test-data")
 
 from app.translate import (
     TranslationResult,
+    FLAG_EMOJI_TO_LANG,
+    get_lang_for_flag,
     get_language_name,
     translate_text,
 )
@@ -29,6 +31,35 @@ def test_get_language_name():
     assert get_language_name("de") == "German"
     assert get_language_name("unknown_code") == "UNKNOWN_CODE"
     assert get_language_name("") == "Unknown"
+
+
+def test_get_lang_for_flag_known():
+    assert get_lang_for_flag("🇫🇷") == "fr"
+    assert get_lang_for_flag("🇩🇪") == "de"
+    assert get_lang_for_flag("🇪🇸") == "es"
+    assert get_lang_for_flag("🇨🇳") == "zh-cn"
+    assert get_lang_for_flag("🇯🇵") == "ja"
+    assert get_lang_for_flag("🇰🇷") == "ko"
+    assert get_lang_for_flag("🇷🇺") == "ru"
+    assert get_lang_for_flag("🇺🇸") == "en"
+    assert get_lang_for_flag("🇬🇧") == "en"
+
+
+def test_get_lang_for_flag_unknown():
+    assert get_lang_for_flag("😀") is None
+    assert get_lang_for_flag("🎉") is None
+    assert get_lang_for_flag("") is None
+    assert get_lang_for_flag(None) is None
+
+
+def test_flag_emoji_mapping_is_extensive():
+    # Sanity: at least 20 distinct languages supported via flag reactions
+    languages = set(FLAG_EMOJI_TO_LANG.values())
+    assert len(languages) >= 20
+    assert "en" in languages
+    assert "es" in languages
+    assert "fr" in languages
+    assert "de" in languages
 
 
 def test_translate_text_empty():

--- a/tests/test_translate_channels.py
+++ b/tests/test_translate_channels.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+import threading
+
+os.environ.setdefault("DISCORD_TOKEN", "mock-token-for-tests")
+os.environ.setdefault("GUILD_ID", "123456789")
+os.environ.setdefault("DATA_DIR", "/tmp/bot-test-data")
+
+from app.translate_channels import AutoTranslateChannelStore
+
+
+def _new_store() -> tuple[AutoTranslateChannelStore, str]:
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "translate_channels.db")
+    lock = threading.RLock()
+    store = AutoTranslateChannelStore(db_path, lock)
+    return store, db_path
+
+
+def test_create_and_list():
+    store, _ = _new_store()
+    store.upsert(123, 456, 789, target_language="en")
+    mappings = store.list_for_guild(123)
+    assert len(mappings) == 1
+    assert mappings[0]["source_channel_id"] == 456
+    assert mappings[0]["target_channel_id"] == 789
+    assert mappings[0]["target_language"] == "en"
+    assert mappings[0]["source_language"] == "auto"
+    assert mappings[0]["enabled"] is True
+
+
+def test_upsert_updates_existing():
+    store, _ = _new_store()
+    store.upsert(123, 456, 789, target_language="en", enabled=True)
+    store.upsert(123, 456, 789, target_language="en", enabled=False)
+    mappings = store.list_for_guild(123)
+    assert len(mappings) == 1
+    assert mappings[0]["enabled"] is False
+
+
+def test_distinct_target_languages_create_distinct_rows():
+    store, _ = _new_store()
+    store.upsert(123, 456, 789, target_language="en")
+    store.upsert(123, 456, 789, target_language="es")
+    mappings = store.list_for_guild(123)
+    languages = sorted(m["target_language"] for m in mappings)
+    assert languages == ["en", "es"]
+
+
+def test_list_active_filters_disabled():
+    store, _ = _new_store()
+    store.upsert(123, 456, 789, target_language="en", enabled=True)
+    store.upsert(123, 456, 790, target_language="es", enabled=False)
+    active = store.list_active_for_source(123, 456)
+    assert len(active) == 1
+    assert active[0]["target_language"] == "en"
+
+
+def test_delete():
+    store, _ = _new_store()
+    store.upsert(123, 456, 789, target_language="en")
+    removed = store.delete(123, 456, 789, "en")
+    assert removed is True
+    assert store.list_for_guild(123) == []
+    # Second delete returns False
+    assert store.delete(123, 456, 789, "en") is False
+
+
+def test_guild_isolation():
+    store, _ = _new_store()
+    store.upsert(111, 100, 200, target_language="en")
+    store.upsert(222, 100, 200, target_language="en")
+    assert len(store.list_for_guild(111)) == 1
+    assert len(store.list_for_guild(222)) == 1
+    assert len(store.list_for_guild(333)) == 0
+
+
+def test_to_json():
+    store, _ = _new_store()
+    store.upsert(123, 456, 789, target_language="fr", source_language="auto")
+    json_str = store.to_json(123)
+    assert "456" in json_str
+    assert "789" in json_str
+    assert "fr" in json_str
+
+
+def test_persistence_across_instances():
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "translate_channels.db")
+    lock = threading.RLock()
+    store1 = AutoTranslateChannelStore(db_path, lock)
+    store1.upsert(123, 456, 789, target_language="en")
+    store2 = AutoTranslateChannelStore(db_path, lock)
+    mappings = store2.list_for_guild(123)
+    assert len(mappings) == 1
+    assert mappings[0]["target_channel_id"] == 789
+
+
+def test_set_enabled():
+    store, _ = _new_store()
+    store.upsert(123, 456, 789, target_language="en", enabled=True)
+    assert store.set_enabled(123, 456, 789, "en", False) is True
+    mappings = store.list_for_guild(123)
+    assert mappings[0]["enabled"] is False
+    # Setting enabled on non-existent row returns False
+    assert store.set_enabled(123, 999, 789, "en", True) is False


### PR DESCRIPTION
Adds two new auto-translation modes alongside the existing right-click context menu (PR #263):

1. **Flag-reaction auto-translate** - React to any message with a country flag emoji (e.g. 🇫🇷, 🇩🇪, 🇨🇳) and the bot posts a translation reply to that language in the same channel.

2. **Dedicated auto-translate channels** - Moderators configure source->target channel mappings via slash commands; the bot automatically forwards every non-trivial message from the source channel to the target with a translation.

Includes 12 new unit tests (189 total pass) covering flag resolution, channel-store CRUD/persistence, and active-only filtering.