### PR TITLE
fix: use valid python:3.11-slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use official Python image, pinned to a specific digest for reproducibility
-FROM python@sha256:56c7b6e2c1e016812dc6e70e6a978f9d0e9987c2e6b618c6b0f0b7d8c5e7b0829c
+# Use official Python image for reproducibility
+FROM python:3.11-slim
 
 # Set working directory inside container
 WORKDIR /app


### PR DESCRIPTION
Restores a valid Docker base image so GHCR builds can publish again.